### PR TITLE
Add Board, GPIO, AIO, PWM, I2C, SPI, UART, Sensor API, and update OCF API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -28,11 +28,24 @@ The following well known structures MAY be implemented in a constrained version:
 
 <a name="events"></a>
 ### Events
-The API uses Node.js-style [events](https://nodejs.org/api/events.html#events_events) with the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface. In constrained implementations, at least the following subset of the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface MUST be supported:
+The API uses Node.js-style [events](https://nodejs.org/api/events.html#events_events) by extending the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface. In constrained implementations, at least the following subset of the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface MUST be supported:
 - the [`on(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) method
 - the [`addListener(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_addlistener_eventname_listener) method, as an alias to the `on()` method
 - the [`removeListener(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener) method
 - the [`removeAllListeners`](https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname) method.
+
+Additionally, for compatibility it is recommended to support the following [EventTarget](https://developer.mozilla.org/en/docs/Web/API/EventTarget) methods:
+- the [`addEventListener(eventName, listener)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) method
+- the [`removeEventListener(eventName, listener)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener) method
+- the [`dispatchEvent(event)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent) method
+- note that listeners receive an [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) object, following the semantics of `EventTarget`(https://developer.mozilla.org/en/docs/Web/API/EventTarget)
+- the [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) objects MUST contain at least the following properties:
+  * [`Event.type`](https://developer.mozilla.org/en-US/docs/Web/API/Event/type)
+  * [`Event.cancelable`](https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable), with the default value `false`
+  * [`Event.bubbles`](https://developer.mozilla.org/en-US/docs/Web/API/Event/bubbles), with the default value `false`
+  * [`Event.eventPhase`](https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase).
+
+Optionally, it is recommended to extend the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface in the way described in [eventobserver.md](./eventobserver.md).
 
 <a name="promise"></a>
 ### Promises

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,56 @@
+IoT Web APIs
+============
+
+<a name="introduction"></a>
+Introduction
+------------
+The following JavaScript APIs are aimed for handling Internet of Things (IoT) applications:
+* Communication APIs such as
+  - [OCF - Open Connect Foundation](./ocf/README.md)
+  - [BLE - Bluetooth Low Energy](./ble/README.md)
+* High level [Sensor APIs](./sensors/README.md) that are standardized in the [W3C Generic Sensor Working Group](https://www.w3.org/2009/dap/) and defines the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/), but adapted to constrained environments. It also exposes interfaces to handle various [sensor types](https://www.w3.org/2009/dap/).
+* Low level [Board APIs](./board/README.md) provide interfaces for I/O operations supported by the board, and define pin mappings between board pin names and pin values mapped by the OS, so that developers could use board pin names in the API methods.
+
+Since implementations of these APIs will partly be running on constrained hardware, they might not support the latest [ECMAScript](http://www.ecma-international.org) versions.
+
+However, implementations should support at least [ECMAScript 5.1](http://www.ecma-international.org/ecma-262/5.1/). Examples use this version, i.e. no string templates or arrow functions are used yet.
+
+[Zephyr.js](https://github.com/01org/zephyr.js) is one implementation of these APIs.
+
+<a name="structures"></a>
+Structures
+----------
+The following well known structures MAY be implemented in a constrained version:
+  - [EventEmitter](#events)
+  - [Promise](#promise)
+  - [Buffer](.#buffer)
+  - [Errors](#errors).
+
+<a name="events"></a>
+### Events
+The API uses Node.js-style [events](https://nodejs.org/api/events.html#events_events) with the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface. In constrained implementations, at least the following subset of the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface MUST be supported:
+- the [`on(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) method
+- the [`addListener(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_addlistener_eventname_listener) method, as an alias to the `on()` method
+- the [`removeListener(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener) method
+- the [`removeAllListeners`](https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname) method.
+
+<a name="promise"></a>
+### Promises
+The API uses [Promises](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects). In constrained implementations, at least the following [`Promise`](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects) methods MUST be implemented:
+- the [`Promise` constructor](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-constructor)
+- the [`then(onFulfilled, onRejected)`](http://www.ecma-international.org/ecma-262/6.0/#sec-promise.prototype.then) method
+- the [`catch(onRejected)`](http://www.ecma-international.org/ecma-262/6.0/#sec-promise.prototype.catch) method.
+
+<a name="buffer"></a>
+### Buffer
+Buffer is a [node.js API](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html)
+to read and write binary data accurately from JavaScript. This API supports a subset that will be expanded on need:
+- constructor with a number argument `size`
+- the `length` property
+- the [`readUint8(offset)`](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_buf_readuint8_offset_noassert) method
+- the [`writeUint8(value, offset)`](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_buf_writeuint8_value_offset_noassert) method
+- the [`toString(encoding)`](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_buf_tostring_encoding_start_end) method.
+
+<a name="errors"></a>
+### Error handling
+Errors are exposed via `onerror` events and `Promise` rejections, using augmented [`Error`](https://nodejs.org/api/errors.html#errors_class_error) objects with added properties.

--- a/api/board/README.md
+++ b/api/board/README.md
@@ -123,7 +123,7 @@ Configures I2C communication. The method runs the following steps:
 - Let `board` be the object representing this board.
 - Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
 - If the I2C functionality is not supported, reject `promise` with `"NotSupportedError"`.
-- Run the [`I2C init`](./i2c.md/#init) steps with `options` and `board` as argument and let `i2c` be the returned result.
+- Run the internal [`I2C initialization`](./i2c.md/#init) algorithm with `options` and `board` as argument and let `i2c` be the returned result.
 - If `i2c` is not `null`, resolve `promise` with the `i2c` object.
 - Otherwise reject `promise`.
 

--- a/api/board/README.md
+++ b/api/board/README.md
@@ -1,0 +1,150 @@
+Board API
+=========
+
+This API provides low level I/O operations supported by hardware boards.
+  - [GPIO - General Purpose I/O](./gpio.md)
+  - [AIO - Analog I/O](./aio.md)
+  - [PWM - Pulse Width Modulation](./pwm.md)
+  - [I2C - Inter-Integrated Circuit](./i2c.md)
+  - [SPI - Serial Peripheral Interface](./spi.md)
+  - [UART - Universal Asynchronous Receiver/Transmitter](./uart.md).
+
+This API uses board pin names as defined by implementations in the [`Board.pins()`](#getpins) and the [`Board.pin()`](#getpin) methods. Implementations SHOULD list pin names, pin addresses, supported modes, and other capabilities or constraints on how the pins can be configured.
+
+The full Web IDL definition for Board and IO APIs can be found [here](./webidl.md).
+
+The API object
+--------------
+The API entry point is a [`Board`](./#board) object that is exposed in a platform specific manner. As an example, on Node.js it can be obtained by requiring the package that implements this API. On other platforms, it can be constructed.
+
+```javascript
+var board = require('iot-board');
+
+// Alternative
+// var board = new Board();  // provides an instance of the default board
+
+console.log("Connected to board " + board.name);
+```
+
+<a name="pin"></a>
+### The `Pin` interface
+Represents a hardware pin on the board.
+
+| Property  | Type   | Optional | Default value | Represents |
+| ---       | ---    | ---      | ---           | ---     |
+| `pin`     | String or Number | no | `undefined`   | board name for the pin |
+| `address` | Number | no       | `undefined`   | pin value defined by the OS |
+| `value`   | Number or object | no       | `undefined`   | value of the pin (synchronous read)|
+| `mode`    | String | no       | `undefined`   | I/O mode |
+| `supportedModes` | array of String | no | `undefined` | pin value defined by the OS |
+
+All properties are read-only.
+
+The `pin` property is the board specific name of a pin defined in the pin mapping of the board.
+
+The `address` property is the operating system specific representation for that pin, usually a number.
+
+<a name="pinmode">
+The `mode` property can take the following values:
+- `"input"` for digital input (GPIO). The pin value can be 0 or 1.
+- `"output"` for digital output (GPIO). The pin value can be 0 or 1.
+- `"analog"` for analog input (AIO) that is converted to digital value.
+- `"pwm"` for PWM analog output.
+
+The `supportedModes` property is an array of modes the board supports for the given pin.  Implementations are not required to implement this property, in which case its value should be `undefined`.
+
+The `value` property is the raw value of a pin with no further interpretation (i.e. if the pin is a digital output active on low, then `1` represents inactive state).
+
+<a name="board"></a>
+### The `Board` interface
+Represents a hardware board. It contains an event handler for errors, and API methods.
+
+| Property          | Type   | Optional | Default value | Represents |
+| ---               | ---    | ---      | ---           | ---     |
+| [`name`](#name)   | String | no       | `undefined`   | board name |
+| [`onerror`](#onerror) | event | no | `undefined`   | event for errors |
+| [`pin()`](#getpin)| function | no | defined by implementation | get a Pin object |
+| [`pins()`](#getpins)| function | no | defined by implementation | get an array of board pin names |
+| [`aio()`](#aio)   | function | no | defined by implementation | get an AIOPin object |
+| [`gpio()`](#gpio) | function | no | defined by implementation | get a GPIO object |
+| [`pwm()`](#pwm)   | function | no | defined by implementation | get a PWMPin object |
+| [`i2c()`](#i2c)   | function | no | defined by implementation | request an I2C object |
+| [`spi()`](#spi)   | function | no | defined by implementation | request an SPI object |
+| [`uart()`](#uart) | function | no | defined by implementation | request an UART object |
+
+<a name="name"></a>
+The `name` property is read-only, and provides the board name.
+
+#### `Board` events
+The `Board` object supports the following events:
+
+| Event name        | Event callback argument |
+| --------------    | ----------------------- |
+| *error*           | [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object |
+
+<a name="onerror"></a>
+Board errors are represented as augmented [`Error`](https://nodejs.org/api/errors.html#errors_class_error) objects. The following [`Error` names](https://nodejs.org/api/errors.html) are used for signaling issues:
+- `BoardDisconnectError`
+- `BoardTimeoutError`
+- `BoardIOError`.
+
+#### `Board` methods
+In all `Board` methods description, `board` denotes a reference to this `Board` object.
+
+<a name="getpin"></a>
+##### The `pin(name)` method
+Returns a [`Pin`](#pin) object associated with the pin name given in the `name` argument. The `name` argument can be a number or a string, as defined in the board pin mapping definition. The returned object describes the current state of the pin.
+
+<a name="getpins"></a>
+##### The `pins()` method
+Returns an array of strings containing the board pin names supported by the board, that can be used in the [`pin()`](#getpin) method.
+
+<a name="gpio"></a>
+##### The `gpio(options)` method
+Returns a [`GPIO`](./gpio.md/#gpio) object associated with the pin name or pin options given in the `options` argument. It runs the following steps:
+- Let `board` be the object representing this board.
+- Run the internal [`GPIO initialization`](./gpio.md/#init) algorithm with `options` and `board` as argument, and return its result. Rethrow any errors that occur.
+
+<a name="aio"></a>
+##### The `aio(options)` method
+Returns an [`AIOPin`](./aio.md/#aio) object associated with the pin name or pin options given in the `name` argument. It runs the following steps:
+- Let `board` be the object representing this board.
+- Run the internal [`AIO initialization`](./aio.md/#init) algorithm with `options` and `board` as argument and return its result. Rethrow any errors that occur.
+
+<a name="pwm"></a>
+##### The `pwm(options)` method
+Returns a [`PWMPin`](./pwm.md/#pwm) object associated with the pin name or pin options given in the [`options`](./pwm.md/#pwmoptions) argument. It runs the following steps:
+- Let `board` be the object representing this board.
+- Run the internal [`PWM initialization`](./pwm.md/#init) algorithm with `options` and `board` as argument and return its result. Rethrow any errors that occur.
+
+<a name="i2c"></a>
+##### The `i2c(options)` method
+Configures I2C communication. The method runs the following steps:
+- Let `board` be the object representing this board.
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If the I2C functionality is not supported, reject `promise` with `"NotSupportedError"`.
+- Run the [`I2C init`](./i2c.md/#init) steps with `options` and `board` as argument and let `i2c` be the returned result.
+- If `i2c` is not `null`, resolve `promise` with the `i2c` object.
+- Otherwise reject `promise`.
+
+<a name="spi"></a>
+##### The `spi(options)` method
+Configures SPI communication.
+The method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If the SPI functionality is not supported, reject `promise` with `"NotSupportedError"`.
+- Let `board` be the object representing this board.
+- Run the [`SPI init`](./spi.md/#init) steps with `options` and `board` as argument and let `spi` be the returned result.
+- If `spi` is not `null`, resolve `promise` with the `spi` object.
+- Otherwise reject `promise`.
+
+<a name="uart"></a>
+##### The `uart(options)` method
+Configures UART communication. It takes a dictionary object as argument.
+The method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If the UART functionality is not supported, reject `promise` with `"NotSupportedError"`.
+- Let `board` be the object representing this board.
+- Run the [`UART init`](./uart.md/#init) steps with `options` as argument and let `uart` be the returned result.
+- If `uart` is not `null`, resolve `promise` with the `uart` object.
+- Otherwise reject `promise`.

--- a/api/board/aio.md
+++ b/api/board/aio.md
@@ -76,7 +76,7 @@ The `rateLimit` property represents the minimum number of milliseconds between t
 
 <a name="init">
 ##### AIO initialization
-This internal algorithm is used by the [`Board.aio()`](./README.md/#aio) method and by the constructor of the [`AIO`](#aio) object. Synchronously configures the AIO pin provided by the `options` (first) argument on the board specified by the `board` (second) argument. It involves the following steps:
+This internal algorithm is used by the [`Board.aio()`](./README.md/#aio) method and by the constructor of the [`AIO`](#aio) object. Synchronously configures the AIO pin provided by the `options` (first) argument on the board specified by the [`board`](./README.md/#board) (second) argument. It involves the following steps:
 - If `options` is a string, create a dictionary 'init' and use the value of `options` to initialize the `init.pin` property.
 - Otherwise if `options` is a dictionary, let `init` be `options`. It may contain the following [`AIO`](#aio) properties:
   * `pin` for board pin name with the valid values defined by the board

--- a/api/board/aio.md
+++ b/api/board/aio.md
@@ -1,0 +1,108 @@
+AIO API
+=======
+
+The AIO API supports reading analog input pins that measure analog voltage signal between 0 and a maximum voltage (usually 3.3 or 5 Volts), then do Analog-to-Digital Conversion (ADC) with a resolution of 10 or 12 bits on most boards, so that the result (pin value) is 0 to 1023 or 0 to 4095, inclusively.
+
+On some boards access to AIO may be asynchronous. This API provides both synchronous and asynchronous read. Also, applications can subscribe to an event that is fired when data is sampled on the pin, and if not interested in all samples, it can also provide a hint to the implementation about a minimum time between two events.
+
+The API object
+--------------
+AIO functionality is exposed by the [`AIO`](#aio) object that can be obtained by using the [aio() method of the `Board` API](./README.md/#aio).
+
+Implementations MAY also support an explicit constructor that runs the [`AIO initialization`](#init) algorithm.
+
+### Examples
+
+```javascript
+try {
+  var board = require("iot-board");
+
+  // Configure AIO using the board
+  var aio1 = board.aio("A1");
+
+  // Configure AIO using a constructor.
+  var aio2 = new AIO("A2", board);
+  // If 'board' is the default board, it can be omitted.
+  // var aio2 = new AIO(2);
+
+  // Read pin values.
+  console.log(board.name + " AIO pin 1 value: " + aio1.value);
+  console.log(board.name + " GPIO pin 2 value: " + aio2.value);
+
+  // Release the pins.
+  aio1.close();
+  aio2.close();
+
+  var aio4 = board.aio({pin: 4, rateLimit: 100 });
+  // will notify 100 or more milliseconds apart
+  aio4.ondata = function(value) {
+    console.log("AIO pin 4 has new reading; value: " + value);
+    aio4.close();  // also removes listeners
+  };
+} catch (err) {
+  console.log("AIO error.");
+}
+```
+
+<a name="aio">
+### The `AIO` interface
+Represents the properties and methods that expose AIO functionality. The `AIO` object implements the [`EventEmitter`](../README/#events) interface, and extends the [`Pin`](./README.md/#pin) object, so it has all properties of [`Pin`](./README.md/#pin). In addition, it has the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| `channel`  | unsigned long | yes   | `undefined` | numeric index of the analog pin |
+| `rateLimit` | unsigned long | yes   | 0 | minimum milliseconds between 'ondata' emits |
+| `read()`   | function | no | defined by implementation | asynchronous read of the pin |
+| `close()`  | function | no | defined by implementation | close the pin |
+| `onchange` | event | no       | `undefined`   | event for pin value change |
+
+#### `AIO` properties
+
+The `pin` property inherited from [`Pin`](./README.md/#pin) can take values defined by the board mapping, usually strings prefixed by `"A"`.
+
+The `mode` property inherited from [`Pin`](./README.md/#pin) takes the value `"analog"`.
+
+The `supportedModes` property inherited from [`Pin`](./README.md/#pin) returns an array of supported modes fot the pin, according to the board documentation. Implementations are not required to implement this property, in which case its value should be `undefined`.
+
+The `value` property inherited from [`Pin`](./README.md/#pin) can take values between 0 and 1024 or between 0 and 4096. Its getter performs a synchronous read operation for the pin value. On platforms where AIO access is asynchronous, the read is blocked until data is available.
+
+The `address` property inherited from [`Pin`](./README.md/#pin) is initialized by implementation with the pin mapping value provided by the board, and represents the identifier of the pin in the given platform and operating system.
+
+The `channel` property is initialized by implementation and provides the numeric index of the analog pin, e.g. it is 0 for pin `"A0"` and 5 for pin `"A5"`.
+
+The `rateLimit` property represents the minimum number of milliseconds between two emits of the `ondata` event. It is used as a hint from applications when initializing AIO pins, and the value is reflecting the capability of the platform (`undefined` when rate limitation is not supported).
+
+#### `AIO` methods
+
+<a name="init">
+##### AIO initialization
+This internal algorithm is used by the [`Board.aio()`](./README.md/#aio) method and by the constructor of the [`AIO`](#aio) object. Synchronously configures the AIO pin provided by the `options` (first) argument on the board specified by the `board` (second) argument. It involves the following steps:
+- If `options` is a string, create a dictionary 'init' and use the value of `options` to initialize the `init.pin` property.
+- Otherwise if `options` is a dictionary, let `init` be `options`. It may contain the following [`AIO`](#aio) properties:
+  * `pin` for board pin name with the valid values defined by the board
+  * `rateLimit`.
+- If any of the `init` properties has invalid value, throw `InvalidAccessError`.
+- If `board` is `undefined` or `null`, let `board` be the default board connected. If no default board exists, throw `InvalidAccessError`.
+- Let `aio` be the `AIO`](#aio) object representing the pin identified by the `name` argument.
+- Initialize the `aio.address` property with the board specific pin mapping value, if available.
+- Request the underlying platform to initialize AIO on the given `board` for the given pin `name`.
+- In case of failure, return `null`.
+- Initialize the `value` property with `undefined`.
+- initialize the `rateLimit` property with the value requested by the application and supported by the platform, or 0 if rate limiting or the requested value is not supported. The board documentations should provide information about the supported rate limit range.
+- Return the `aio` object.
+
+##### The `Promise<unsigned long> read()` method
+Performs an asynchronous read operation for the pin value. It returns a promise that is resolved with the pin value when the next sample is available. On platforms where AIO access is synchronous, implementation can resolve the promise immediately with the pin value.
+
+##### The `close()` method
+Called when the application is no longer interested in the pin. This also removes all listeners to the `ondata` event. Until the next [initialization](#init), invoking the `read()` method or reading the `value` property SHOULD throw `InvalidAccessError`.
+
+
+#### `AIO` events
+The `AIO object supports the following events:
+
+| Event name        | Event callback argument |
+| --------------    | ----------------------- |
+| `ondata`          | unsigned long (the new pin value) |
+
+The `ondata` event will be emitted every time a new sample is available, and the time since the last emit is more than `rateLimit`. The listener callback will receive the current value of the pin.

--- a/api/board/arduino101.md
+++ b/api/board/arduino101.md
@@ -18,7 +18,7 @@ Pins (A0 - A5) can be used for analog input, and each provide 10 bits of resolut
 There are 3 LEDs on the board that can be accessed by the pin names `"LED0"`, `"LED1"`, and `"LED3"`.
 
 Other names:
-- UART on pin 0 and 1 can be accessed by the name `"uart0`".
+- UART on pin 0 and 1 can be accessed by the name `"uart0"`.
 - UART on USB can be accessed by the name `"serialUSB0"`, `"serialUSB2"`, etc.
 - I2C can be accessed by default on bus 0 (the SDA and SCL pins).
 - SPI can be accessed by default on bus 0. SPI pins on the board are:

--- a/api/board/arduino101.md
+++ b/api/board/arduino101.md
@@ -1,0 +1,57 @@
+Board Supportfor Arduino 101
+============================
+
+This page defines the values returned by the [`Board.pins()`](./README.md/#getpins) method, and describes the pin mapping for the [`Board.pin()`](./README.md/#getpin) method, from board labels that are printed on the board to operating system specific values.
+
+The board labels are described in the [Arduino 101](https://www.arduino.cc/en/Main/ArduinoBoard101) board documentation. Also, for each board pin, the [`supportedModes`](./README.md/#pin) property of each pin is described.
+
+The [Arduino 101](https://www.arduino.cc/en/Main/ArduinoBoard101) board has 20 I/O pins that operate at 3.3 V and can be configured as described by the following table.
+
+Pins 0 and 1 can be also configured to be used as UART, the port name is exposed as `uart0`.
+
+On GPIO pins (0..13) interrupts can be configured to be triggered on low value, high value, rising edge, and falling edge. Some of the GPIO pins can trigger interrupt on value *change* (pins 2, 5, 7, 8, 10, 11, 12, 13).
+
+Pins 3,5,6 and 9 can be used for PWM output. These pins are marked on the board by a ~ (tilde) symbol next to the pin numbers. Pin 3 corresponds to PWM channel 0, pin 9 to PWM channel 3, etc.
+
+Pins (A0 - A5) can be used for analog input, and each provide 10 bits of resolution (i.e. 1024 different values).
+
+There are 3 LEDs on the board that can be accessed by the pin names `"LED0"`, `"LED1"`, and `"LED3"`.
+
+Other names:
+- UART on pin 0 and 1 can be accessed by the name `"uart0`".
+- UART on USB can be accessed by the name `"serialUSB0"`, `"serialUSB2"`, etc.
+- I2C can be accessed by default on bus 0 (the SDA and SCL pins).
+- SPI can be accessed by default on bus 0. SPI pins on the board are:
+  * SS (Slave Select) on pin 10
+  * MOSI  (Master Out Slave In) on pin 11
+  * MISO (Master In Slave Out) on pin 12
+  * SCK (Serial Clock) on pin 13.
+
+Arduino 101 pins are summarized in the following table.
+
+|Pin name |Supported modes (channel), [other]  |
+| ---     | ---                                |
+| `0`     | `"input"`, `"output"`, [UART0 RX]  |
+| `1`     | `"input"`, `"output"`, [UART0 TX]  |
+| `2`     | `"input"`, `"output"`              |
+| `3`     | `"input"`, `"output"`, `"pwm"`(0)  |
+| `4`     | `"input"`, `"output"`              |
+| `5`     | `"input"`, `"output"`, `"pwm"`(1)  |
+| `6`     | `"input"`, `"output"`, `"pwm"`(2)  |
+| `7`     | `"input"`, `"output"`              |
+| `8`     | `"input"`, `"output"`              |
+| `9`     | `"input"`, `"output"`, `"pwm"`(3)  |
+| `10`    | `"input"`, `"output"`, [SPI SS]    |
+| `11`    | `"input"`, `"output"`, [SPI MOSI]  |
+| `12`    | `"input"`, `"output"`, [SPI MISO]  |
+| `13`    | `"input"`, `"output"`, [SPI SCK]   |
+| `"A0"`  | `"analog"`(0)                      |
+| `"A1"`  | `"analog"`(1)                      |
+| `"A2"`  | `"analog"`(2)                      |
+| `"A3"`  | `"analog"`(3)                      |
+| `"A4"`  | `"analog"`(4)                      |
+| `"A5"`  | `"analog"`(5)                      |
+| `"LED0"`| `"output"` (active on 1)           |
+| `"LED1"`| `"output"` (active on 0)           |
+| `"LED2"`| `"output"` (active on 0)           |
+

--- a/api/board/frdm_k64f.md
+++ b/api/board/frdm_k64f.md
@@ -1,0 +1,45 @@
+Board Support for FRDM-K64F
+===========================
+
+The FRDM-K64F board pin names and locations are shown [here](https://developer.mbed.org/platforms/FRDM-K64F/).
+
+Theere are 16 general purpose I/O pins, `D0` - `D15`. `D14` and `D15` can be used as GPIO inputs but not outputs currently.
+
+There is an onboard RGB LED which can be controlled through three different GPIO outputs for the red, green, and blue components. `LEDR` controls the red portion, `LEDG` the green portion, and `LEDB` the blue
+portion. They are all active on high.
+
+There are three onboard switches labeled `SW2`, `SW3`, and `RESET`. The `SW2` switch can be used as a GPIO input. The `RESET` switch can be used as an output.
+
+There are ten pins that can be used as PWM output, `PWM0` - `PWM9`.
+
+There are six analog input pins, `A0` - `A5`.
+
+Supported pins are summarized in the following table.
+
+|Pin name |Supported modes (channel), [other]   |
+| ---     | ---                                 |
+| `D0`    | `"input"`, `"output"`, [UART3 RX]   |
+| `D1`    | `"input"`, `"output"`, [UART3 TX]   |
+| `D2`    | `"input"`, `"output"`               |
+| `D3`    | `"input"`, `"output"`, `"pwm"`(0)   |
+| `D4`    | `"input"`, `"output"`               |
+| `D5`    | `"input"`, `"output"`, `"pwm"`(1)   |
+| `D6`    | `"input"`, `"output"`, `"pwm"`(2)   |
+| `D7`    | `"input"`, `"output"`, `"pwm"`(3)   |
+| `D8`    | `"input"`, `"output"`, `"pwm"`(4)   |
+| `D9`    | `"input"`, `"output"`, `"pwm"`(5)   |
+| `D10`   | `"input"`, `"output"`, `"pwm"`(6)   |
+| `D11`   | `"input"`, `"output"`, `"pwm"`(7), [SPI MOSI] |
+| `D12`   | `"input"`, `"output"`, `"pwm"`(8), [SPI MISO] |
+| `D13`   | `"input"`, `"output"`, `"pwm"`(9), [SPI SCK]  |
+| `D14`   | `"input"`, [I2C SDA]                |
+| `D15`   | `"input"`, [I2C SCL]                |
+| `"A0"`  | `"analog"`(0)                       |
+| `"A1"`  | `"analog"`(1)                       |
+| `"A2"`  | `"analog"`(2)                       |
+| `"A3"`  | `"analog"`(3)                       |
+| `"A4"`  | `"analog"`(4), `"pwm"`              |
+| `"A5"`  | `"analog"`(5), `"pwm"`              |
+| `"LED0"`| `"output"` (active on 1)            |
+| `"LED1"`| `"output"` (active on 0)            |
+| `"LED2"`| `"output"` (active on 0)            |

--- a/api/board/gpio.md
+++ b/api/board/gpio.md
@@ -1,0 +1,115 @@
+GPIO API
+========
+
+The GPIO API supports digital I/O pins.
+
+The API object
+--------------
+GPIO functionality is exposed by the [`GPIO`](#gpio) object that can be obtained by using the [gpio() method of the `Board` API](./README.md/#gpio).
+
+Implementations MAY also support an explicit constructor that runs the [`GPIO initialization`](#init) algorithm.
+
+### Examples
+
+```javascript
+try {
+  var board = require("iot-board");
+
+  // Configure GPIO using the board
+  var gpio3 = board.gpio(3);  // GPIO input pin with default configuration.
+
+  // Configure GPIO using a constructor.
+  var gpio4 = new GPIO(4, board);
+  // If 'board' is the default board, it can be omitted.
+  // var gpio4 = new GPIO(4);
+
+  // Read pin values.
+  console.log(board.name + " GPIO pin 3 value: " + gpio3.value);
+  console.log(board.name + " GPIO pin 4 value: " + gpio4.value);
+
+  // Release the pins.
+  gpio3.close();
+  gpio4.close();
+
+  var gpio5 = board.gpio({ pin: 5, mode: "output", activeLow: true });
+  gpio5.write(0);  // activate pin 2
+  gpio5.close();
+
+  var gpio6 = board.gpio({pin: 6, edge: "any"});
+  // will notify on both 0->1 and 1->0 changes.
+  gpio4.onchange = function(value) {
+    console.log("GPIO pin 6 has changed; value: " + value);
+    gpio6.close();  // also removes listeners
+  };
+} catch (err) {
+  console.log("GPIO error.");
+}
+```
+
+<a name="gpio">
+### The `GPIO` interface
+Represents the properties and methods that expose GPIO functionality. The `GPIO` object implements the [`EventEmitter`](../README/#events) interface, and extends the [`Pin`](./README.md/#pin) object, so it has all properties of [`Pin`](./README.md/#pin). In addition, it has the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| `activeLow` | boolean | yes   | `false` | whether the pin is active on logical low |
+| `edge`     | string | yes      | `"any"`       | Interrupt generation mode |
+| `pull`     | string | yes      | `"none"`      | "pulldown", "pullup" or "none" |
+| `write()`  | function | no | defined by implementation | synchronous write |
+| `close()`  | function | no | defined by implementation | close the pin |
+| `onchange` | event | no       | `undefined`   | event for pin value change |
+
+#### `GPIO` properties
+
+The `pin` property inherited from [`Pin`](./README.md/#pin) can take values defined by the board mapping, usually positive integers.
+
+The `mode` property inherited from [`Pin`](./README.md/#pin) can take the values `"input"` or `"output"`. The default value is `"input"`. Other [`Pin.mode`](./README.md/#pinmode) values are invalid for GPIO.
+
+The `supportedModes` property inherited from [`Pin`](./README.md/#pin) returns an array of supported modes fot the pin, according to the board documentation. Implementations are not required to implement this property, in which case its value should be `undefined`.
+
+The `value` property inherited from [`Pin`](./README.md/#pin) provides the raw value of the pin, 0 (meaning `low`, or `false`) or 1 (meaning `high`, or `true`) or `undefined`. The default value is `undefined`, meaning  the input may be floating, and output is not specified. When reading the property, implementations SHOULD make a synchronous read operation to fetch the value of the pin.
+
+The `address` property inherited from [`Pin`](./README.md/#pin) is initialized by implementation with the pin mapping value provided by the board, and represents the identifier of the pin in the given platform and operating system.
+
+The `activeLow` property tells whether the pin value 0 means active. If `activeLow` is `true`, with `value` 0 the pin is active, otherwise inactive. For instance, if an actuator is attached to the (output) pin active on low, client code should write the value 0 to the pin in order to activate the actuator.
+
+The `edge` property is used for input pins and tells whether the `onchange` event is emitted on the rising edge of the signal (string value `"rising"`) when `value` changes from 0 to 1, or on falling edge (string value `"falling"`) when `value` changes from 1 to 0, or both edges (string value `"any"`), or never (string value `"none`"). The default value is `"none"`, which means by default the `onchange` events will fire on any change.
+
+The `pull` property tells if the internal pulldown (string value `"pulldown"`) or pullup (string value `"pullup"`) resistor is used for input pins to provide a default value (0 or 1) when the input is floating. The default value is `"none"`, meaning no resistor is used and the input is floating.
+
+#### `GPIO` methods
+
+<a name="init">
+##### GPIO initialization
+This internal algorithm is used by the [`Board.gpio()`](./README.md/#gpio) method and by the constructor of the [`GPIO`](#gpio) object. Synchronously configures the GPIO pin provided by the `options` (first) argument on the board specified by the `board` (second) argument.
+- If `options` is a number or a string, create a dictionary `init` and use the value of `options` to initialize the `init.pin` property.
+- Otherwise if `options` is a dictionary, let `init` be `options`. It may contain the following [`GPIO`](#gpio) properties:
+  * `pin` for board pin name with the valid values defined by the board
+  * `mode` with valid values `"input"` or `"output"`, by default `"input"`
+  * `activeLow`, by default `false`
+  * `edge`, by default `"any"`
+  * `pull`, by default `"none"`.
+- If any of the `init` properties has invalid value, throw `InvalidAccessError`.
+- If `board` is `undefined` or `null`, let `board` be the default board connected. If no default board exists, throw `InvalidAccessError`.
+- Let `gpio` be the `GPIO`](#gpio) object representing the requested pin initialized by `init`. For the [`GPIO`](#gpio) properties missing from the `init` dictionary, implementations SHOULD use the default values of the `GPIO` object properties.
+- Initialize the `address` property with the board specific pin mapping value, if available.
+- Request the underlying platform to initialize GPIO on the given `board` with the `init` properties.
+- In case of failure, return `null`.
+- Initialize the `value` property with the current value of the pin, if available.
+- Return the `gpio` object.
+
+##### The `write(value)` method
+If `value` is `0`, `null` or `undefined`, let `value` be 0. Otherwise let `value` be `1`.
+The method synchronously writes 0 or 1 to the GPIO pin, to provide its raw value. If `activeLow` is `true`, the value 0 activates the pin, and the value 1 inactivates it. If `activeLow` is `false`, the value 1 activates the pin, and the value 0 deactivates it.
+
+##### The `close()` method
+Called when the application is no longer interested in the pin. This also removes all listeners to the `onchange` event. Until the next invocation of `init()`, invoking the `write()` method or reading the `value` property SHOULD throw `InvalidAccessError`.
+
+#### `GPIO` events
+The `GPIO object supports the following events:
+
+| Event name        | Event callback argument |
+| --------------    | ----------------------- |
+| `onchange`        | boolean (the new pin value) |
+
+The listener callback will receive the current value of the pin (0 or 1).

--- a/api/board/gpio.md
+++ b/api/board/gpio.md
@@ -81,7 +81,7 @@ The `pull` property tells if the internal pulldown (string value `"pulldown"`) o
 
 <a name="init">
 ##### GPIO initialization
-This internal algorithm is used by the [`Board.gpio()`](./README.md/#gpio) method and by the constructor of the [`GPIO`](#gpio) object. Synchronously configures the GPIO pin provided by the `options` (first) argument on the board specified by the `board` (second) argument.
+This internal algorithm is used by the [`Board.gpio()`](./README.md/#gpio) method and by the constructor of the [`GPIO`](#gpio) object. Synchronously configures the GPIO pin provided by the `options` (first) argument on the board specified by the [`board`](./README.md/#board) (second) argument.
 - If `options` is a number or a string, create a dictionary `init` and use the value of `options` to initialize the `init.pin` property.
 - Otherwise if `options` is a dictionary, let `init` be `options`. It may contain the following [`GPIO`](#gpio) properties:
   * `pin` for board pin name with the valid values defined by the board

--- a/api/board/i2c.md
+++ b/api/board/i2c.md
@@ -1,0 +1,4 @@
+I2C API
+=======
+
+Until the I2C API description appears here, take a look at the [Web IDL](./webidl.md).

--- a/api/board/i2c.md
+++ b/api/board/i2c.md
@@ -1,4 +1,78 @@
 I2C API
 =======
 
-Until the I2C API description appears here, take a look at the [Web IDL](./webidl.md).
+The I2C API supports Inter-Integrated Circuit (IIC, I2C), a synchronous serial protocol that allows multiple slave chips to communicate with a master chip. A single I2C bus uses 2 pins, SDA (data) and SCL (clock). Multiple I2C buses may be present on a board.
+I2C selects the slave device by addressing: the first byte sent by the master chip contains the 7 bit address of a slave, and one bit for direction (read or write). Slaves acknowledge each byte received from the master by sending 0 on SDA (both SDA and SCL are pulled high in I2C).
+If read was requested, the master will emit clock, and the selected slave will provide bits to the master as long as clock is emitted.
+If write was requested, the master puts the bit on SDA and sends a clock signal for data available.
+Therefore it is important to select the right speed supported by the master and slave devices.
+This API uses a [`Buffer`](../README.mk/#buffer) object for both read and write.
+
+The API object
+--------------
+I2C functionality is exposed by the [`I2C`](#i2c) object that can be obtained by using the [i2c() method of the `Board` API](./README.md/#i2c). See also the [Web IDL](./webidl.md).
+
+```javascript
+try {
+  var board = require("iot-board");
+
+  board.i2c().then(function(i2c) {
+    console.log("I2C bus " + i2c.bus + " opened with bus speed " + i2c.speed);
+    i2c.write(0x02, [1, 2, 3]).then(function() {
+      i2.read(0x03, 3).then(function(buffer) {
+        // Buffer object
+        console.log("From I2C device 0x03: " + buffer.toString());
+        i2c.close();
+      });
+    });
+  }).catch(function(err) {
+    console.log("I2C error: " + err.message);
+  });
+}
+```
+
+<a name="i2c">
+### The `I2C` interface
+Represents the properties and methods that expose I2C functionality. The `I2C` object has the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| `bus`      | octet  | yes      | platform selected | I2C bus |
+| `speed`    | long   | yes      | platform selected | I2C bus speed |
+
+The `bus` property denotes the I2C bus number between 0 and 127.
+
+The `speed` property can take the following numeric values denoting kilobits per second: 10, 100, 400, 1000, 3400.
+
+#### I2C methods
+<a name="init">
+##### I2C initialization
+This internal algorithm is used by the [`Board.i2c()`](./README.md/#i2c) method. Configures the I2C bus and bus speed provided by the `options` (first) dictionary argument on the [`board`](./README.md/#board) specified by the `board` (second) argument.
+- Let `i2c` be an `I2C`](#i2c) object.
+- If `options` is a dictionary and the `options.bus` property is a number between 0 and 127, let `i2c.bus` be `options.bus`, otherwise select the platform default value, and if that is not available, set the value to 0.
+- If `options.speed` is not a number, let `i2c.speed` be 10. Otherwise, if it is in the { 10, 100, 400, 1000, 3400 } set, let `i2c.speed` take that value, otherwise set `i2c.speed` to the closest matching value.
+- Request the underlying platform to initialize the I2C `bus` with `i2c.speed` on `board`.
+- In case of failure, return `null`.
+- Return `i2c`.
+
+##### The `write(device, buffer)` method
+Writes a [`Buffer`](./README.md/#buffer) using I2C to slave `device`. The method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If `device` is not a number between 0 and 127, reject `promise` with `TypeError` and terminate these steps.
+- Create a [`Buffer`](./README.md/#buffer) from `buffer`. If that fails, reject `promise` with `TypeError` and terminate these steps.
+- Request the underlying platform to write the specified bytes to the specified device.
+If the operation fails, reject `promise`.
+- Otherwise, resolve `promise`.
+
+##### The `read(device, size)` method
+Reads maximum `size` number of bytes from I2C device `device` and resolves with a [`Buffer`](./README.md/#buffer). The method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If `device` is not a number between 0 and 127, reject `promise` with `TypeError` and terminate these steps.
+- Create a [`Buffer`](./README.md/#buffer) from `buffer`.
+- Request the underlying platform to read `size` number of bytes from the specified `device` into `buffer`.
+If the operation fails, reject `promise`.
+- Otherwise, resolve `promise` with `buffer`.
+
+
+##### The `close()` method
+Closes the current [`I2C`](#i2c) bus and interrupts all pending operations.

--- a/api/board/pwm.md
+++ b/api/board/pwm.md
@@ -79,7 +79,7 @@ The `value` property inherited from [`Pin`](./README.md/#pin) provides a diction
 
 <a name="init">
 ##### PWM initialization
-This internal algorithm is used by the [`Board.pwm()`](./README.md/#pwm) method and by the constructor of the [`PWM`](#pwm) object. Synchronously configures the PWM pin provided by the `options` (first) argument on the board specified by the `board` (second) argument. It involves the following steps:
+This internal algorithm is used by the [`Board.pwm()`](./README.md/#pwm) method and by the constructor of the [`PWM`](#pwm) object. Synchronously configures the PWM pin provided by the `options` (first) argument on the board specified by the [`board`](./README.md/#board) (second) argument. It involves the following steps:
 - If `options` is a string or number, then create a dictionary `init` and use the value of `options` to initialize the `init.pin` property.
 - Otherwise if `options` is a dictionary, let `init` be `options`. It may contain the following [`PWM`](#pwm) properties:
   * `pin` for board pin name with the valid values defined by the board

--- a/api/board/pwm.md
+++ b/api/board/pwm.md
@@ -1,0 +1,112 @@
+PWM API
+=======
+
+The PWM API supports writing analog values to pins using Pulse Width Modulation. Usually PWM is used for controlling LEDs, fans, vibration, etc.
+
+PWM is characterized by a repeating digital signal of given pulse width (duration for value 1 in normal polarity and for value 0 in reverse polarity) and a total duration of the signal (period). Also, PWM is characterized by a duty cycle that is the ratio between the pulse width and the total signal period.
+For instance, a LED that is driven with a PWM signal with 50% duty cycle will be approximately half bright.
+
+The term 'channel' is used to refer to the fact that PWM controller hardware has multiple channels, but they are exposed as output pins. In this API the value of a channel is the numeric index of a PWM pin relative to the controller.
+
+The API object
+--------------
+PWM functionality is exposed by the [`PWM`](#pwm) object that can be obtained by using the [pwm() method of the `Board` API](./README.md/#pwm).
+
+Implementations MAY also support an explicit constructor that runs the [`PWM initialization`](#init) algorithm.
+
+### Examples
+
+```javascript
+try {
+  var board = require("iot-board");
+
+  var pwm6 = board.pwm(6);  // configure pin 6 as PWM
+  // Alternatives:
+  // var pwm6 = new PWM(6, board);  // use this board
+  // var pwm6 = new PWM(6);  // use the default (this) board
+
+  // Specify and enable PWM signal in terms of milliseconds.
+  pwm6.write({ period: 2.5, pulseWidth: 1.5 });  // duty cycle is 60%
+  console.log("PWM duty cycle: " + pwm.value.dutyCycle);
+
+  // Stop the PWM signal.
+  pwm6.stop();
+
+  // Stop the PWM signal and release the pin.
+  pwm6.close();
+} catch (err) {
+  console.log("AIO error.");
+}
+
+```
+
+<a name="pwm">
+### The `PWM` interface
+Represents the properties and methods that expose PWM functionality. The `PWM` object extends the [`Pin`](./README.md/#pin) object, so it has all properties of [`Pin`](./README.md/#pin). In addition, it has the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| `channel`  | unsigned long  | yes | `undefined` | numeric index of the analog pin |
+| `reversePolarity` | boolean | yes |   `false`   | PWM polarity |
+| `write()`  | function | no | defined by implementation | set and enable PWM signal |
+| `stop()`   | function | no | defined by implementation | stop the PWM signal |
+| `close()`  | function | no | defined by implementation | release the pin |
+
+#### `PWM` properties
+
+The `pin` property inherited from [`Pin`](./README.md/#pin) can take values defined by the board mapping.
+
+The `address` property inherited from [`Pin`](./README.md/#pin) is initialized by implementation with the pin mapping value provided by the board, and represents the identifier of the pin in the given platform and operating system.
+
+The `mode` property inherited from [`Pin`](./README.md/#pin) takes the value `"pwm"`.
+
+The `supportedModes` property inherited from [`Pin`](./README.md/#pin) returns an array of supported modes fot the pin, according to the board documentation. Implementations are not required to implement this property, in which case its value should be `undefined`.
+
+The `channel` property is initialized by the implementation and provides the numeric index of the analog pin, e.g. it is 0 for pin `"A0"` and 5 for pin `"A5"`.
+
+The `reversePolarity` property tells whether the PWM signal is active on 0. The default value is `false`.
+
+<a name="pwmdata">
+The `value` property inherited from [`Pin`](./README.md/#pin) provides a dictionary with the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| period     | double | no       | `undefined`   | the total period of the PWM signal in milliseconds |
+| pulseWidth | double | no       | `undefined`   | the period of the PWM pulse in milliseconds |
+| dutyCycle  | long   | no       | `undefined`   | the calculated PWM duty cycle |
+
+#### `PWM` methods
+
+<a name="init">
+##### PWM initialization
+This internal algorithm is used by the [`Board.pwm()`](./README.md/#pwm) method and by the constructor of the [`PWM`](#pwm) object. Synchronously configures the PWM pin provided by the `options` (first) argument on the board specified by the `board` (second) argument. It involves the following steps:
+- If `options` is a string or number, then create a dictionary `init` and use the value of `options` to initialize the `init.pin` property.
+- Otherwise if `options` is a dictionary, let `init` be `options`. It may contain the following [`PWM`](#pwm) properties:
+  * `pin` for board pin name with the valid values defined by the board
+  * `reversePolarity`, with a default value `false`.
+- If any of the `init` properties has invalid value, throw `InvalidAccessError`.
+- If `board` is `undefined` or `null`, let `board` be the default board connected. If no default board exists, throw `InvalidAccessError`.
+- initialize the `reversePolarity` property with the value requested by the application.
+- Let `pwm` be the `PWM`](#pwm) object representing the pin identified by the `name` argument.
+- Request the underlying platform to initialize AIO on the given `board` for the given pin `name`.
+- In case of failure, return `null`.
+- Initialize the `pwm.address` property with the board specific pin mapping value, if available.
+- Initialize the `pwm.channel` property with the board specific value, if available.
+- Initialize the `value` property with the dictionary described [here](#pwmdata) with default property values.
+- Return the `pwm` object.
+
+##### The `write(value)` method
+Performs a synchronous write operation to define and enable the PWM signal. The argument `value` is a [dictionary defined here](#pwmdata) with at least 2 properties specified:
+- `period` and `pulseWidth`, or
+- `period` and `dutyCycle`, or
+- `pulseWidth` and `dutyCycle`.
+The third property of `value` is calculated based on the other two. If all properties are specified, `dutyCycle` is recalculated based on the value of `period` and `pulseWidth`.
+The method runs the following steps:
+- If `value` has invalid values for the given board, throw `InvalidAccessError`.
+- Set up and enable the PWM signal based on `value`.
+
+##### The `stop()` method
+Disables the PWM signal on the pin. A new invocation of `write()` is needed.
+
+##### The `close()` method
+Called when the application is no longer interested in the pin. It invokes the `stop()` method, then releases the pin.

--- a/api/board/spi.md
+++ b/api/board/spi.md
@@ -1,4 +1,86 @@
 SPI API
 =======
 
-Until the SPI API description appears here, take a look at the [Web IDL](./webidl.md).
+The SPI API supports Serial Peripheral Interface, a synchronous serial protocol that allows multiple slave chips to communicate with a master chip. A single SPI bus uses 4 pins, SCK for clock, SS for slave select, MOSI (Master Out, Slave In) for write, and MISO (Master In, Slave Out) for read. Multiple SPI buses may be present on a board.
+For each clock signal one bit is written from the master to the selected slave and one bit is read by the master from the selected slave, so there is no separate read and write, but one transfer operation.
+When a slave device's chip select is 0 (low), then it communicates with the master, otherwise it ignores the master.
+This API uses a [`Buffer`](../README.mk/#buffer) object for both read and write.
+
+The API object
+--------------
+SPI functionality is exposed by the [`SPI`](#spi) object that can be obtained by using the [spi() method of the `Board` API](./README.md/#spi). See also the [Web IDL](./webidl.md).
+
+```javascript
+try {
+  var board = require("iot-board");
+
+  board.spi().then(function(spi) {
+    console.log("SPI bus " + spi.bus + " opened with bus speed " + spi.speed);
+    console.log("SPI mode: " + spi.mode);
+    console.log("Data bits: " + spi.bits);
+    console.log("Speed [MHz]: " + spi.speed);
+    console.log("MSB: " + (spi.msb ?  "true" : "false"));
+
+    spi.transfer(0, [1, 2, 3]).then(function(buffer) {
+        // Buffer object
+        console.log("From SPI device 0: " + buffer.toString());
+        spi.close();
+      });
+    });
+  }).catch(function(err) {
+    console.log("SPI error: " + err.message);
+  });
+}
+```
+
+<a name="SPI">
+### The `SPI` interface
+Represents the properties and methods that expose SPI functionality. The `SPI` object has the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| `bus`      | octet  | yes      | 0             | SPI bus |
+| `speed`    | long   | yes      | 20            | SPI bus speed in MHz |
+| `msb`      | boolean | yes     | 1             | MSB (or LSB) first |
+| `bits`     | number | yes      | 8             | number of data bits |
+| `mode`     | enum   | yes      | 'mode0'    | SPI mode (polarity, sampling) |
+
+The `bus` property denotes the SPI bus number between 0 and 127.
+
+The `speed` property is a floating point number that denotes the SPI bus speed in MHz. Usually it is between 10 and 66 MHz.
+
+The `msb` property is a boolean denoting whether the most significant bit (MSB) is sent first, or the least significant bit (LSB). The default value is `true` (MSB first).
+
+The `bits` property is a number denoting the number of data bits (word size). Usually it is 1, 2, 4, 8 or 16. The default value is 4.
+
+The `mode` property denotes the SPI mode, i.e.
+- `"mode0"`, normal polarity, phase 0, sampled on leading clock
+- `"mode1"`, polarity normal, phase 1, sampled on trailing clock
+- `"mode2"`, polarity inverse, phase 0, sampled on leading clock
+- `"mode3"`  polarity inverse, phase 1, sampled on trailing clock.
+
+#### SPI methods
+<a name="init">
+##### SPI initialization
+This internal algorithm is used by the [`Board.spi()`](./README.md/#spi) method. Configures the SPI bus and bus speed provided by the `options` (first) dictionary argument on the [`board`](./README.md/#board) specified by the `board` (second) argument.
+- Let `spi` be an `SPI`](#spi) object.
+- If `options` is a dictionary and the `options.bus` property is a number between 0 and 127, let `spi.bus` be `options.bus`, otherwise select the platform default value, and if that is not available, set the value to 0.
+- If `options.speed` is not a number, let `spi.speed` be 10. Otherwise, set `spi.speed` to the closest matching value that is lower than `options.speed` and is supported by the platform.
+- If `options.msb` is `false`, set `spi.msb` to `false`, otherwise set it to `true`.
+- If `options.bits` is in the set {1, 2, 4, 8, 16 }, then set `spi.bits` to `option.bits`, otherwise set it to the value 4.
+- If `options.mode` is in the set `{ 'mode0', 'mode1', 'mode2', 'mode3' }`, then set `spi.mode` to that, otherwise set it to `'mode0'`.
+- Request the underlying platform to initialize the SPI `spi.bus` with `spi.speed` on `board`.
+- In case of failure, return `null`.
+- Return `spi`.
+
+##### The `transfer(device, buffer)` method
+Writes a [`Buffer`](./README.md/#buffer) `buffer` using SPI to the slave `device`, and reads another [`Buffer`](./README.md/#buffer) from the slave device that is returned. The method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If `device` is not a number between 0 and 127, reject `promise` with `TypeError` and terminate these steps.
+- Create a [`Buffer`](./README.md/#buffer) from `buffer` (may be empty). If that fails, reject `promise` with `TypeError` and terminate these steps.
+- Request the underlying platform to write the specified `buffer` to the specified device and read another [`Buffer`](./README.md/#buffer) `readBuffer`.
+If the operation fails, reject `promise`.
+- Otherwise, resolve `promise` with `readBuffer`.
+
+##### The `close()` method
+Closes the current [`SPI`](#spi) bus and interrupts all pending operations.

--- a/api/board/spi.md
+++ b/api/board/spi.md
@@ -1,0 +1,4 @@
+SPI API
+=======
+
+Until the SPI API description appears here, take a look at the [Web IDL](./webidl.md).

--- a/api/board/uart.md
+++ b/api/board/uart.md
@@ -1,4 +1,93 @@
 UART API
 ========
 
-Until the UART API description appears here, take a look at the [Web IDL](./webidl.md).
+The UART API supports Universal Asynchronous Receiver/Transmitter that allows to the board to communicate with other external devices. It uses 2 pins, RX for receiving and TX for transmit. UART ports are usually referred by string names (see board definitions), but numbers may also be accepted.
+This API uses a [`Buffer`](../README.mk/#buffer) object for both read and write.
+
+The API object
+--------------
+UART functionality is exposed by the [`UART`](#uart) object that can be obtained by using the [uart() method of the `Board` API](./README.md/#uart). See also the [Web IDL](./webidl.md).
+
+```javascript
+try {
+  var board = require("iot-board");
+
+  board.uart("serialUSB0").then(function(uart) {
+    console.log("UART port " + uart.port);
+    console.log("Speed [bps]: " + uart.speed);
+    console.log("Data bits: " + uart.dataBits);
+    console.log("Stop bits: " + uart.stopBits);
+    console.log("Parity: " + uart.parity);
+    console.log("Flow control " + (uart.flowControl ? "on." : "off.");
+
+    uart.setReadRange(8, 16);  // min 8 byes, max 16 bytes in one read event
+
+    uart.on("read", function(buffer) {
+      console.log("UART received: " + buffer.toString());
+    });
+
+    uart.write([1, 2, 3]);
+
+  }).catch(function(err) {
+    console.log("UART error: " + err.message);
+  });
+}
+```
+
+<a name="UART">
+### The `UART` interface
+Represents the properties and methods that expose UART functionality. The `UART` interface implements the [`EventEmitter`](../README/#events) interface and exposes one event with name `onread`.
+
+| Event name        | Event callback argument |
+| --------------    | ----------------------- |
+| `onread`          | [`Buffer`](../README.mk/#buffer) |
+
+The `UART` object has the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| `port`     | String | no       | undefined     | UART port |
+| `speed`    | number | yes      | 115200        | UART baud rate |
+| `dataBits` | number | yes      | 8             | number of data bits |
+| `stopBits` | number | yes      | 1             | number of stop bits |
+| `parity`   | enum   | yes      | `'none'`      | `'none'`, `'even'`, `'odd'` |
+| `flowControl` | boolean | yes  | `false`       | if flow control is on |
+
+The `port` property denotes the UART port as a string defined by the board documentation, such as `"tty0"`, `"serialUSB0"`, etc.
+
+
+The `speed` property represents the baud rate and its value can be 9600, 19200, 38400, 57600, 115200 (by default).
+
+The `dataBits` property represents the number of data bits (word size), and it can be between 5 and 8 (by default).
+
+The `stopBits` property represents the number of stop bits and can take the value 1 (by default) or 2.
+
+The `parity` property can take the following values: `"none"` (by default), `"even"`, and `"odd"`.
+
+The `flowControl` boolean property denotes if flow control is used. By default it is `false`.
+
+#### UART methods
+<a name="init">
+##### UART initialization
+This internal algorithm is used by the [`Board.uart()`](./README.md/#uart) method. Configures UART with the `options` (first) dictionary argument on the [`board`](./README.md/#board) specified by the `board` (second) argument.
+- If `options.port` is not a string, return `null`.
+- Let `uart` be an `UART`](#uart) object.
+- For all `uart` properties, if the `options` dictionary defines the same property with a valid value, let the `uart` property take that value, otherwise the default value.
+- Request the underlying platform to initialize the UART with the parameters provided by `uart`.
+- In case of failure, return `null`.
+- Invoke the `uart.setReadRange(min, max)` method with `min` = 1, and `max` taking a value determined by the platform that is greater or equal than 1.
+- Return `uart`.
+
+##### The `write(buffer)` method
+Transmits a [`Buffer`](./README.md/#buffer) using UART. The method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- Create a [`Buffer`](./README.md/#buffer) from `buffer`. If that fails, reject `promise` with `TypeError` and terminate these steps.
+- Request the underlying platform to send the specified bytes.
+If the operation fails, reject `promise`.
+- Otherwise, resolve `promise`.
+
+##### The `setReadRange(min, max)` method
+Sets the minimum and maximum number of bytes for triggering the `onread` event. Whenever at least `min` number of bytes is available, a [`Buffer`](./README.md/#buffer) object containing a `max` number of bytes is sent with the `onread` event.
+
+##### The `close()` method
+Closes the current [`UART`](#uart) port and interrupts all pending operations.

--- a/api/board/uart.md
+++ b/api/board/uart.md
@@ -1,0 +1,4 @@
+UART API
+========
+
+Until the UART API description appears here, take a look at the [Web IDL](./webidl.md).

--- a/api/board/webidl.md
+++ b/api/board/webidl.md
@@ -1,0 +1,179 @@
+Web IDL for Board and IO APIs
+
+```javascript
+
+interface Board {
+    attribute EventHandler onerror;
+
+    Pin pin(PinName);  // board specific dictionary for mapping pins
+    sequence<String> pins();  // get all board pin names
+
+    AIO aio(PinName pin);
+    GPIO gpio( (PinName or GPIOOptions) options);
+    PWM pwm( (PinName or PWMOptions) options);
+
+    Promise<I2C> i2c(I2COptions options);
+    Promise<SPI> spi(SPIOptions options);
+    Promise<UART> uart(UARTOptions options);
+};
+
+Board implements EventEmitter;
+
+typedef (long or unsigned long or double or unrestricted double) Number;
+typedef (DOMString or USVString) String;
+typedef (Number or String) PinName;  // implementation uses board specific mapping
+
+enum { "input", "output", "analog", "pwm" } PinMode;
+
+interface Pin {
+    readonly attribute PinName pin;  // board number/name of the pin
+    readonly attribute PinName address;  // platform number/name of the pin
+    readonly attribute PinMode mode;
+    readonly attribute Number value;  // provides a synchronous read()
+    readonly attribute sequence<PinMode> supportedModes;
+};
+
+// GPIO
+dictionary GPIOOptions {
+    PinName pin;
+    PinMode mode = "input";
+    boolean activeLow = false;
+    String edge = "any";  // "none", "rising", "falling", "any"
+    String pull = "none"; // "none", "pullup", "pulldown"
+};
+
+[Constructor(GPIOOptions options, optional Board board)]
+interface GPIO: Pin {
+    void write(boolean value);
+    void close();
+    attribute EventHandler<boolean> onchange;
+};
+
+GPIO implements EventEmitter;
+
+// AIO
+
+dictionary AIOOptions {
+  PinName pin;
+  unsigned long rate;
+};
+
+[Constructor( (PinName or AIOOptions) pin, optional Board board)]
+interface AIO: Pin {
+    unsigned long channel;  // analog channel
+    unsigned long rateLimit;     // rate limit for ondata
+    Promise<unsigned long> read();  // one-shot async read
+    void close();
+    attribute EventHandler<unsigned long> ondata;
+};
+
+AIO implements EventEmitter;
+
+// PWM
+dictionary PWMOptions {
+  PinName pin;
+  boolean reversePolarity = false;
+};
+
+[Constructor(PWMOptions options, optional Board board)]
+interface PWM: Pin {
+    readonly attribute unsigned long channel;
+    readonly attribute boolean reversePolarity;
+    // 'value' returns PWMData
+    void write(PWMData value);
+    void stop();
+    void close();
+};
+
+dictionary PWMData {
+  double period;
+  double pulseWidth;
+  double dutyCycle;
+};
+
+// I2C
+enum I2CSpeed { "10kbps", "100kbps", "400kbps", "1000kbps", "3400kbps" };
+
+dictionary I2COptions {
+  octet bus;
+  I2CSpeed speed;
+};
+
+[NoInterfaceObject]
+interface I2C {
+  readonly attribute octet bus;
+  readonly attribute I2CBusSpeed speed;
+  readonly attribute boolean busy;
+
+  Promise init(I2COptions options);
+  void requestRead(octet device,
+                                unsigned long size,
+                                optional octet register,
+                                optional repetitions = 1);
+  Promise write(octet device, (USVString or sequence<octet>) data, optional octet register);
+  Promise writeBit(octet device, boolean data);
+  void abort();  // abort all current read / write operations
+  void close();
+
+  attribute EventHandler<sequence<octet>> ondata;
+  attribute EventHandler onerror;
+};
+
+I2C implements EventEmitter;
+
+// SPI
+typedef (sequence<octet> or ArrayBuffer) SPIData;
+
+enum SPIMode {
+
+  "mode0",  // polarity normal, phase 0, i.e. sampled on leading clock
+  "mode1",  // polarity normal, phase 1, i.e. sampled on trailing clock
+  "mode2",  // polarity inverse, phase 0, i.e. sampled on leading clock
+  "mode3"   // polarity inverse, phase 1, i.e. sampled on trailing clock
+};
+
+enum SPIDataOrder { "msb", "lsb" };
+
+dictionary SPIOptions {
+  unsigned long bus = 0;
+  SPIMode mode = "mode0";
+  boolean msb = 1;  // 1: MSB first, 0: LSB first
+  unsigned long dataBits = 8; // 1, 2, 4, 8, 16
+  double speed = 20;  // in MHz, usually 10..66 MHz
+};
+
+[NoInterfaceObject]
+interface SPI {
+  // has all the properties of SPIOptions as read-only attributes
+  Promise init(SPIOptions options);
+  Promise<SPIData> transfer(SPIData txData);
+  void close();
+};
+
+// UART
+enum UARTBaud { "baud-9600", "baud-19200", "baud-38400", "baud-57600", "baud-115200" };
+enum UARTDataBits { "databits-5", "databits-6", "databits-7", "databits-8" };
+enum UARTStopBits { "stopbits-1", "stopbits-2" };
+enum UARTParity { "none", "even", "odd" };
+
+dictionary UARTOptions {
+  DOMString port;
+  UARTBaud baud = "115200";
+  UARTDataBits dataBits = "8";
+  UARTStopBits stopBits = "1";
+  UARTParity parity = "none";
+  boolean flowControl = false;
+};
+
+typedef (USVString or sequence<octet> or ArrayBuffer) UARTData;
+
+[NoInterfaceObject]
+interface UARTConnection: EventTarget {
+  // has all the properties of UARTInit as read-only attributes
+  Promise init(UARTOptions options);
+  void close();
+  Promise<void> write(UARTData data);
+  attribute EventHandler<octet> onread;
+};
+
+```

--- a/api/eventobserver.md
+++ b/api/eventobserver.md
@@ -1,0 +1,164 @@
+
+Event Observers
+===============
+
+This is a proposal for a minimal event handling interface based on watches that monitor, filter and handle events in IoT use cases. It can be implemented with minimal polyfill on top of `EventTarget` or `EventEmitter`, in browser, Node.js and constrained runtimes.
+
+Based on use cases and issues from the [W3C Generic Sensor API](https://github.com/w3c/sensors/issues/21), the [W3C Web of Things](https://github.com/w3c/wot/issues/235),  and [Node.js style events](https://nodejs.org/api/events.html#events_events), it seems there are divergent views on how (sensor reading) events should be handled in IoT.
+
+[Observables](https://github.com/tc39/proposal-observable) are also a proposed model to handle asynchronous samples streams. [Xstream](https://github.com/staltz/xstream) is also targeting similar use cases. Even though there is a lot of overlap, these seem to be slightly different use cases than the one in IoT implementations.
+
+The minimum feature set needed in IoT:
+- Event emitters with multiple event listeners (= streams).
+- Functionality for adding listeners.
+- Functionality for removing listeners.
+- Optional filters on events.
+
+An `event` for IoT may need to contain the following informations:
+- event name
+- data representation, including
+  * timestamp
+  * data origin
+  * other properties from the data model.
+
+Another requirement would be that client code written in browser should be compatible with Node.js clients and also with constrained JS runtimes.
+
+The best existing structure to fulfill these requirements would be [EventSource](https://developer.mozilla.org/en/docs/Web/API/EventSource), see also a [Node.js implementation](https://www.npmjs.com/package/eventsource). However, it carries too many things for constrained implementations.
+
+The following proposal distillates the most needed features in a minimal package; it inherits `EventEmitter`, implements `EventTarget` for compatibility, and overloads the `on()` method to return a watch that is used in a manner similar to `Subscription` in [Observables](https://github.com/tc39/proposal-observable).
+
+Web IDL
+=======
+```javascript
+
+EventObserver: EventEmitter {
+  // 'on()' now takes an optional filter and returns a watch
+  EventWatch on(String eventName,
+                optional EventHandler listener,
+                optional Filter filter);
+};
+
+EventObserver implements EventTarget;
+// addEventListener, removeEventListener, dispatchEvent
+
+interface EventWatch {
+  void cancel();  // remove all filters and listener and cancel this watch
+
+  // syntactic sugar for managing filters and listener
+  EventWatch filter(Filter filter);  // append a new filter, return `this`
+  void listener(EventHandler listener);  // replace listener
+};
+
+callback EventFilter = boolean (any data);
+
+typedef (Dictionary or EventFilter) Filter;
+```
+
+A practical application would be reporting sensor data.
+
+```javascript
+interface SensorData {
+  readonly attribute String timestamp;
+  readonly attribute String origin;  // the URL of the data source
+  // ... other properties, according to the data model
+};
+
+[Constructor (String name, optional SensorData data)]
+interface SensorEvent: Event {
+  readonly attribute SensorData data;
+};
+
+```
+
+Using `EventObserver`
+=====================
+
+Objects that normally implement `EventTarget` or `EventEmitter`, will implement `EventObserver` instead, and will expose event names normally as `EventHandler` properties.
+
+Listeners are added to events as before, only that `on()` now returns an `EventWatch` object instead of `EventEmitter` self reference, so we lose cascading (of course, `EventWatch` could extend `EventEmitter` to solve that, but not in this version).
+
+Also, `on()` will accept an optional filter, either a dictionary where all properties must match a property in event data, or a filter function that receives event data and returns `true` or `false`.
+
+The returned `EventWatch` object always refers to one event, has one listener, 0 or more filters, and exposes:
+- a `cancel()` function for the watch, that removes all filters and the listener,
+- a method to append a new filter to the watch,
+- a method to change the listener associated to the watch.
+
+When a filter is a function, receives the same arguments as listeners.
+When a filter is a dictionary, the listener MUST receive only one argument that is an object, and each property found in the filter MUST value-match a property with the same name in the argument object in order that the listener is invoked.
+
+When a new filter is appended to the watch, it is applied after the previous filters, so it restricts more and more the invocation of the event listener.
+
+Since a listener can be added or changed in a watch, the listener parameter to the `on()` method becomes optional. A watch without a listener just doesn't work, i.e. it does not invoke any listener, until one is added.
+
+Note that the filtering functionality could be part of the listeners themselves, and then `EventObserver` would be reduced to `EventEmitter`. However, in IoT, using watches brings added value for cancellation, clarity with explicit cumulative filters, and flexibility with replaceable listeners.
+
+Also note that watches are only supported by the overloaded `on()` method of `EventEmitter`, and `EventTarget` is supported in [compatibility mode](#eventtarget).
+
+How `EventObserver` is used in specifications:
+```javascript
+
+interface MyObject : EventObserver {
+  // ...
+  attribute EventHandler onchange;
+  attribute EventHandler ondelete;
+  // ...
+};
+```
+
+And how is it used in client code:
+```javascript
+var obj = new MyObject();
+
+watch = obj.on("change")
+  .filter(function(data) {
+    if (data.threshold > 0)
+      return true;
+    return false;
+  }).listener(function(data) {
+    // now it is guaranteed that data.threshold > 0
+)
+
+// ...
+
+watch.cancel();
+
+// alternative syntax, without filter
+watch = obj.on("change", function(data) {
+  // use data;
+  console.log("Timestamp: " + data.timestamp);
+  console.log("Origin: " + data.origin);
+});
+
+// alternative syntax, with data filter
+watch = obj.on("change", function(data) {
+  // use data;
+}, { value: 0 });  // will trigger only when data.value is 0
+
+```
+
+<a name="promise"></a>
+`EventTarget` compatibility
+===========================
+In constrained runtimes it is recommended to support the following [EventTarget](https://developer.mozilla.org/en/docs/Web/API/EventTarget) methods:
+- the [`addEventListener(eventName, listener)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) method
+- the [`removeEventListener(eventName, listener)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener) method
+- the [`dispatchEvent(event)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent) method
+- note that listeners receive an [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) object, following the semantics of `EventTarget`(https://developer.mozilla.org/en/docs/Web/API/EventTarget)
+- the [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) objects MUST contain at least the following properties:
+  * [`Event.type`](https://developer.mozilla.org/en-US/docs/Web/API/Event/type)
+  * [`Event.cancelable`](https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable), with the default value `false`
+  * [`Event.bubbles`](https://developer.mozilla.org/en-US/docs/Web/API/Event/bubbles), with the default value `false`
+  * [`Event.eventPhase`](https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase).
+
+```javascript
+
+var obj = new MyObject();
+
+obj.addEventListener("change", function(event) {
+  // use event.data as listeners receive an Event object
+  console.log("Timestamp: " + event.data.timestamp);
+  console.log("Origin: " + event.data.origin);
+});
+
+```

--- a/api/ocf/README.md
+++ b/api/ocf/README.md
@@ -48,8 +48,8 @@ The Client API implements CRUDN (Create, Retrieve, Update, Delete, Notify) funct
 
 The Server API implements the functionality to serve CRUDN requests in a device. It also provides the means to register and unregister resources, to notify of resource changes, and to enable and disable presence functionality on the device.
 
-## Structures
-
+Structures
+----------
 <a name="ocfdevice"></a>
 ### The `OcfDevice` object
 Exposes information about the OCF device that runs the current OCF stack instance.
@@ -85,7 +85,7 @@ Exposes information about the OCF platform that hosts the current device.
 
 Errors during OCF network operations are exposed via `onerror` events and `Promise` rejections.
 
-OCF errors are represented as augmented [`Error`](https://nodejs.org/api/errors.html#errors_class_error) objects with added properties. The following [`Error` names](https://nodejs.org/api/errors.html) are used for signaling OCF issues:
+OCF errors (see also [these notes](../README.md#errors)) are represented as augmented [`Error`](https://nodejs.org/api/errors.html#errors_class_error) objects with added properties. The following [`Error` names](https://nodejs.org/api/errors.html) are used for signaling OCF issues:
 - `OcfDiscoveryError`
 - `OcfObserveError`
 - `OcfPresenceError`.
@@ -118,22 +118,13 @@ var err = new OcfObserveError(message, deviceId, resourcePath);
 
 Implementations SHOULD handle the `uncaughtException` event on the process object.
 
-<a name="ocfpromise"></a>
-### Promises
-The API uses [Promises](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects). In constrained implementations, at least the following [`Promise`](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects) methods MUST be implemented:
-- the [`Promise` constructor](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-constructor)
-- the [`then(onFulfilled, onRejected)`](http://www.ecma-international.org/ecma-262/6.0/#sec-promise.prototype.then) method
-- the [`catch(onRejected)`](http://www.ecma-international.org/ecma-262/6.0/#sec-promise.prototype.catch) method.
+Notes
+------
 
-<a name="events"></a>
-### Events
-The API uses Node.js-style [events](https://nodejs.org/api/events.html#events_events) with the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface. In constrained implementations, at least the following subset of the [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter) interface MUST be supported:
-- the [`on(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_on_eventname_listener) method
-- the [`addListener(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_addlistener_eventname_listener) method, as an alias to the `on()` method
-- the [`removeListener(eventName, callback)`](https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener) method
-- the [`removeAllListeners`](https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname) method.
+The API uses [Promises](http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects) with [these notes](../README.md#promise).
 
-## Notes
+The API uses Node.js-style [events](https://nodejs.org/api/events.html#events_events) with [these notes](../README.md#events).
+
 Code using this API is deployed to a device which exposes one or more resources. In this version of the API it is assumed that the execution context of the code is separated for each device.
 
 **Device identification** is UUID.

--- a/api/ocf/client.md
+++ b/api/ocf/client.md
@@ -49,7 +49,7 @@ The Client API supports the following events:
 | *devicefound*     | [`Device`](./README.md/#device) object |
 | *devicelost*      | [`Device`](./README.md/#device) object |
 | *resourcefound*   | [`Resource`](#resource) object |
-| *error*           | [`Error`](#ocferror) object |
+| *error*           | [`Error`](../README.md/#ocferror) object |
 
 <a name="onplatformfound"></a>
 ##### 2.1. The `platformfound` event

--- a/api/ocf/client.md
+++ b/api/ocf/client.md
@@ -20,10 +20,6 @@ Identifies an OCF resource by the UUID of the device that hosts the resource, an
 #### `Resource` properties
 `Resource` extends `ResourceId`, it has all the properties of [`ResourceInit`](./server.md#resourceinit), and in addition it has events.
 
-| Property   | Type    | Optional | Default value | Represents |
-| ---        | ---     | ---      | ---           | ---     |
-| `id` | [`ResourceId`](#resourceid) | no    | `undefined` | Resource identifier |
-
 Client applications should not create `Resource` objects, as they are created and tracked by implementations. Client applications can create and use `ResourceId`, [`ResourceInit`](./server.md/#resourceinit) and even `Resource` objects as method arguments, but client-created `Resource` objects are not tracked by implementations and will not receive events.
 
 #### `Resource` events
@@ -87,7 +83,7 @@ When the last listener is removed from the `ondevicefound` and the `ondevicelost
 Fired when a resource is discovered. The event callback receives as argument a [`Resource`](#resource) object.
 ```javascript
 client.on('resourcefound', function(resource) {
-  console.log("Resource found with path: " + resource.id.path);
+  console.log("Resource found with path: " + resource.resourcePath);
 });
 ```
 
@@ -111,7 +107,7 @@ Fetches a remote platform information object.  The `deviceId` argument is a stri
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
 - If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- Send a direct discovery request `GET /oic/p` with the given id (which can be either a device UUID or a device URL, and wait for the answer.
+- Send a direct discovery request `GET /oic/p` with the given `deviceId` (which can be either a device UUID or a device URL, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, resolve `promise` with a [`Platform`](./README.md/#platform) object created from the response.
 
@@ -128,7 +124,7 @@ Fetches a remote device information object. The `deviceId` argument is a string 
 <a name="findplatforms"></a>
 ##### 3.3. The `findPlatforms(listener)` method
 - Initiates a platform discovery network operation.
-- Returns a [`Promise`](./README.md/#promise) object that resolves with a [`Platform`](./README.md/#platform) object.
+- Returns a [`Promise`](./README.md/#promise) object.
 - The `listener` argument is optional, and is an event listener for the [`platformfound`](#onplatformfound) event that receives as argument a [`Platform`](./README.md/#platform) object.
 
 The method runs the following steps:
@@ -144,7 +140,7 @@ The method runs the following steps:
 <a name="finddevices"></a>
 ##### 3.4. The `findDevices(listener)` method
 - Initiates a device discovery network operation.
-- Returns a [`Promise`](./README.md/#promise) object that resolves with a [`Device`](./README.md/#device) object.
+- Returns a [`Promise`](./README.md/#promise) object.
 - The `listener` argument is optional, and is an event listener for the [`devicefound`](#ondevicefound) event that receives as argument a [`Device`](./README.md/#device) object.
 
 The method runs the following steps:
@@ -160,7 +156,7 @@ The method runs the following steps:
 <a name="findresources"></a>
 ##### 3.5. The `findResources(options, listener)` method
 - Initiates a resource discovery network operation.
-- Returns a [`Promise`](./README.md/#promise) object that resolves with a [`Resource`](#resource) object.
+- Returns a [`Promise`](./README.md/#promise) object.
 - The `options` parameter is optional, and its value is an object that contains one or more of the following properties:
 
 | Property       | Type   | Optional | Default value | Represents        |
@@ -210,7 +206,7 @@ The method runs the following steps:
 ##### 4.2. The `retrieve(resourceId, options, listener)` method
 - Retrieves a resource based on resource id by sending a request to the device specified in `resourceId.deviceId`. The device's [`retrieve`](./server.md/#onretrieve) event handler takes care of fetching the resource representation and replying with the created resource, or with an error.
 - Returns a [`Promise`](./README.md/#promise) object which resolves with a [Resource](#resource) object.
-- The `resourceId` argument is a [ResourceId](#resourceid) object that contains a device UUID and a resource path.
+- The `resourceId` argument is a [ResourceId](#resourceid) object that contains a device UUID and a resource path. Note that any [`Resource`](#resource) object can also be provided.
 - The `options` argument is optional, and it is an object whose properties represent the `REST` query parameters passed along with the `GET` request as a JSON-serializable dictionary. Implementations SHOULD validate this client input to fit OCF requirements. The semantics of the parameters are application-specific (e.g. requesting a resource representation in metric or imperial units). Similarly, the properties of an OIC resource representation are application-specific and are represented as a JSON-serializable dictionary.
 - The `listener` argument is optional, and is an event listener for the `Resource` [`update`](#onresourceupdate) event.
 
@@ -232,8 +228,8 @@ The method runs the following steps:
 
 <a name="update"></a>
 ##### 4.3. The `update(resource)` method
-- Updates a resource in the network by sending a request to the device specified by `resource.id.deviceId`. The device's [`update`](./server.md/#onupdate) event handler takes care of updating the resource and replying with the updated resource, or with an error. The resource identified by `resource.id` is updated so that every property present in `resource` other than `resource.id` is updated with the value specified in `resource`.
-- Returns: a [`Promise`](./README.md/#promise) object which resolves with a [Resource](#resource) object.
+- Updates a resource in the network by sending a request to the device specified by `resource.deviceId`. The device's [`update`](./server.md/#onupdate) event handler takes care of updating the resource and replying with the updated resource, or with an error. The resource identified by `resource` is updated.
+- Returns: a [`Promise`](./README.md/#promise) object.
 - The `resource` argument is a [Resource](#resource) object.
 
 The method runs the following steps:
@@ -242,7 +238,6 @@ The method runs the following steps:
 - If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to update the resource specified by `resource` with the properties present in `resource`, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error, otherwise resolve `promise`.
-
 
 <a name="delete"></a>
 ##### 4.4. The `delete(resourceId)` method

--- a/api/sensors/README.md
+++ b/api/sensors/README.md
@@ -25,9 +25,10 @@ interface Sensors {
     // Enumerate all sensors or a given type of sensors connected to the board.
     // If a type was provided, the first in the list is the default sensor of that type.
     sequence<Sensor> sensors(optional SensorType sensorType);
-    attribute EventHandler<Sensor> onsensorconnected;
-    attribute EventHandler<Sensor> onsensordisconnected;
+    attribute EventHandler<Sensor> onsensorfound;
+    attribute EventHandler<Sensor> onsensorlost;
 };
+
 Sensors implement EventEmitter;
 
 partial interface Sensor {
@@ -46,3 +47,88 @@ enum SensorType {
     "ProximitySensor"
 };
 ```
+
+The Web IDL of [Generic Sensor](https://w3c.github.io/sensors/#the-sensor-interface) is the following:
+<a name="sensor">
+```javascript
+interface Sensor : EventTarget {
+  readonly attribute SensorState state;
+  readonly attribute SensorReading? reading;
+  void start();
+  void stop();
+  attribute EventHandler onchange;
+  attribute EventHandler onstatechange;
+  attribute EventHandler onerror;
+};
+
+dictionary SensorOptions {
+  double? frequency;
+};
+
+enum SensorState {
+  "idle",
+  "activating",
+  "active",
+  "errored"
+};
+
+interface SensorReading {
+  readonly attribute DOMHighResTimeStamp timeStamp;
+};
+
+[Constructor(DOMString type, SensorReadingEventInit eventInitDict)]
+interface SensorReadingEvent : Event {
+  readonly attribute SensorReading reading;
+};
+
+dictionary SensorReadingEventInit : EventInit {
+  SensorReading reading;
+};
+
+```
+Various sensors may add properties to [`Sensor`](#sensor), or to its `reading` property of type `SensorReading`.
+
+###  The data model for lightmeter
+The `reading` property of the sensor is a dictionary that contains a new property named `illuminance` that is a floating point number and represents the current light level (illuminance) measured in lux.
+
+### The data model for proximity sensor
+The `reading` property of the sensor is a dictionary that contains the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| distance   | double | no       | undefined     | distance to object in cm |
+| max        | double | no       | undefined     | sensing range in cm      |
+| near       | boolean | no      | undefined     | if object in proximity   |
+
+### The data model for accelerometer
+The `reading` property of the sensor is a dictionary that contains the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| accelerationX | double | no    | undefined  | acceleration along the X axis |
+| accelerationY | double | no    | undefined  | acceleration along the Y axis |
+| accelerationZ | double | no    | undefined  | acceleration along the Z axis |
+
+The sensor contains one more additional property named `includesGravity` of type `boolean`. If it is `false`, then the `reading` property stores linear acceleration values (that don't take into account gravity).
+
+### The data model for gyroscope
+The `reading` property of the sensor is a dictionary that contains the following properties that represent the current angular velocity around the X, Y or Z axis, expressed in radians per second:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| rotationRateX | double | no    | 0  | angular velocity along the X axis |
+| rotationRateY | double | no    | 0  | angular velocity along the Y axis |
+| rotationRateZ | double | no    | 0  | angular velocity along the Z axis |
+
+### The data model for magnetometer
+The `reading` property of the sensor is a dictionary that contains the following properties that represent the geomagnetic field force around the X, Y or Z axis, expressed in microTesla units:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| magneticFieldX | double | no    | 0  | geomagnetic field along the X axis |
+| magneticFieldY | double | no    | 0  | geomagnetic field along the Y axis |
+| magneticFieldZ | double | no    | 0  | geomagnetic field along the Z axis |
+
+
+### The data model for geolocation
+Work in progress.

--- a/api/sensors/README.md
+++ b/api/sensors/README.md
@@ -1,0 +1,48 @@
+Sensor APIs
+===========
+
+This API is based on the [W3C Generic Sensor API](https://www.w3.org/TR/generic-sensor) but adapted to constrained environments. It exposes interfaces to handle various [sensor types](https://www.w3.org/2009/dap/).
+  - [Ambient Light Sensor](./ambient-light.md) type, based on the [W3C Ambient Light Sensor specification](https://www.w3.org/TR/ambient-light/).
+  - [Proximity Sensor](./proximity.md) type, based on the [W3C Proximity Sensor specification](https://www.w3.org/TR/proximity).
+  - [Accelerometer Sensor](./accelerometer.md) type, based on the [W3C Accelerometer specification](https://github.com/w3c/accelerometer).
+  - [Gyroscope Sensor](./gyroscope.md) type, based on the [W3C Gyroscope specification](https://w3c.github.io/gyroscope/).
+  - [Magnetometer Sensor](./magnetometer.md) type, based on the [W3C MagnetoMeter specification](https://w3c.github.io/magnetometer).
+
+This API takes interface definitions for the following objects from the [W3C Generic Sensor API](https://www.w3.org/TR/generic-sensor):
+- [Sensor](https://www.w3.org/TR/generic-sensor/#the-sensor-interface)
+- [SensorReading](https://www.w3.org/TR/generic-sensor/#the-sensor-reading-interface)
+- [SensorReadingEvent](https://www.w3.org/TR/generic-sensor/#the-sensor-reading-event-interface)
+- [SensorErrorEvent](https://www.w3.org/TR/generic-sensor/#the-sensor-error-event-interface).
+
+### Changes compared to the W3C specifications
+
+There are changes on how `Sensor` objects are obtained. In this API `Sensor objects are not constructed, but exposed via the [`Board`](../board/README.md) object. Also, this API lists all sensors of a given type, not only the default one. Also, this API adds two more properties to the `Sensor` object, for exposing a sensor name, and the name of the hardware controller. In rest, the sensor interfaces are the same.
+
+## Web IDL for Sensor APIs
+```javascript
+// Provided by 'require()'.
+interface Sensors {
+    // Enumerate all sensors or a given type of sensors connected to the board.
+    // If a type was provided, the first in the list is the default sensor of that type.
+    sequence<Sensor> sensors(optional SensorType sensorType);
+    attribute EventHandler<Sensor> onsensorconnected;
+    attribute EventHandler<Sensor> onsensordisconnected;
+};
+Sensors implement EventEmitter;
+
+partial interface Sensor {
+    // Additional properties to W3C Generic Sensor.
+    readonly attribute String name;  // e.g. "bedroomLightSensor1"
+    readonly attribute String controller;  // e.g. "ISL29035", or "Grove" etc.
+};
+
+// Using the 'instanceof' type names for the W3C sensor types.
+enum SensorType {
+    "AmbientLightSensor",
+    "Accelerometer",
+    "GeolocationSensor",
+    "Gyroscope",
+    "Magnetometer",
+    "ProximitySensor"
+};
+```


### PR DESCRIPTION
Added the general structure for the Board API, including board definitions for Arduino 101 and FRDM-K64F. Added GPIO, AIO and PWM APIs. Added full Web IDL also for I2C, SPI and UART API, but text descriptions are missing. 

Added Sensor API, based on W3C Generic Sensor (with approved changes). 

Fixed incorrect descriptions of Promises in the OCF Client API (the Web IDL has been correct). Fixes #7.