### PR TITLE
Add Bluetooth Smart API. Fixes to OCF and Board APIs.

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -5,11 +5,11 @@ IoT Web APIs
 Introduction
 ------------
 The following JavaScript APIs are aimed for handling Internet of Things (IoT) applications:
-* Communication APIs such as
-  - [OCF - Open Connect Foundation](./ocf/README.md)
-  - [BLE - Bluetooth Low Energy](./ble/README.md)
 * High level [Sensor APIs](./sensors/README.md) that are standardized in the [W3C Generic Sensor Working Group](https://www.w3.org/2009/dap/) and defines the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/), but adapted to constrained environments. It also exposes interfaces to handle various [sensor types](https://www.w3.org/2009/dap/).
 * Low level [Board APIs](./board/README.md) provide interfaces for I/O operations supported by the board, and define pin mappings between board pin names and pin values mapped by the OS, so that developers could use board pin names in the API methods.
+* Communication APIs, such as
+  - [OCF - Open Connect Foundation](./ocf/README.md) API
+  - [BLE - Bluetooth Low Energy](./ble/README.md) API (Peripheral mode).
 
 Since implementations of these APIs will partly be running on constrained hardware, they might not support the latest [ECMAScript](http://www.ecma-international.org) versions.
 

--- a/api/README.md
+++ b/api/README.md
@@ -4,23 +4,23 @@ IoT Web APIs
 <a name="introduction"></a>
 Introduction
 ------------
-The following JavaScript APIs are aimed for handling Internet of Things (IoT) applications:
-* High level [Sensor APIs](./sensors/README.md) that are standardized in the [W3C Generic Sensor Working Group](https://www.w3.org/2009/dap/) and defines the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/), but adapted to constrained environments. It also exposes interfaces to handle various [sensor types](https://www.w3.org/2009/dap/).
-* Low level [Board APIs](./board/README.md) provide interfaces for I/O operations supported by the board, and define pin mappings between board pin names and pin values mapped by the OS, so that developers could use board pin names in the API methods.
-* Communication APIs, such as
-  - [OCF - Open Connect Foundation](./ocf/README.md) API
-  - [BLE - Bluetooth Low Energy](./ble/README.md) API (Peripheral mode).
+The following JavaScript APIs are aimed for handling Internet of Things (IoT) applications.
+
+* [Sensor API](./sensors/README.md): high level sensor APIs standardized in the [W3C Generic Sensor Working Group](https://www.w3.org/2009/dap/) and defines the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/), but adapted to constrained environments. It also exposes interfaces to handle various [sensor types](https://www.w3.org/2009/dap/).
+* [Board API](./board/README.md): provides low level interfaces for I/O operations supported by the board, and define pin mappings between board pin names and pin values mapped by the OS, so that developers could use board pin names in the API methods.
+* [OCF - Open Connect Foundation](./ocf/README.md) API
+* [Bluetooth Smart API](./ble/README.md) API (Peripheral mode).
 
 Since implementations of these APIs will partly be running on constrained hardware, they might not support the latest [ECMAScript](http://www.ecma-international.org) versions.
 
-However, implementations should support at least [ECMAScript 5.1](http://www.ecma-international.org/ecma-262/5.1/). Examples use this version, i.e. no string templates or arrow functions are used yet.
+However, implementations should support at least [ECMAScript 5.1](http://www.ecma-international.org/ecma-262/5.1/). Examples are limited to ECMAScript 5.1 with the exception of using Promises.
 
 [Zephyr.js](https://github.com/01org/zephyr.js) is one implementation of these APIs.
 
 <a name="structures"></a>
 Structures
 ----------
-The following well known structures MAY be implemented in a constrained version:
+The following structures MAY be implemented in a constrained version:
   - [EventEmitter](#events)
   - [Promise](#promise)
   - [Buffer](.#buffer)

--- a/api/README.md
+++ b/api/README.md
@@ -15,8 +15,6 @@ Since implementations of these APIs will partly be running on constrained hardwa
 
 However, implementations should support at least [ECMAScript 5.1](http://www.ecma-international.org/ecma-262/5.1/). Examples are limited to ECMAScript 5.1 with the exception of using Promises.
 
-[Zephyr.js](https://github.com/01org/zephyr.js) is one implementation of these APIs.
-
 <a name="structures"></a>
 Structures
 ----------

--- a/api/ble/README.md
+++ b/api/ble/README.md
@@ -1,0 +1,305 @@
+IoT Bluetooth Smart API
+=======================
+
+- [The `BluetoothPeripheralDevice` interface](#bpd)
+- [`BluetoothPeripheralDevice` events]
+  * [enabledchange](#onenabledchange)
+  * [connect](#onconnect)
+  * [disconnect](#ondisconnect)
+  * [error](#onerror)
+- [`BluetoothPeripheralDevice` methods]
+  * [enable()](#enable)
+  * [disable()](#disable)
+  * [startAdvertising(advertisement, options)](#startadvertising)
+  * [stopAdvertising()](#stopadvertising)
+  * [addService(service)](#addservice)
+  * [removeService(service)](#removeservice)
+- [The `BluetoothService` dictionary](#service)
+- [The `BluetoothDescriptor` dictionary](#descriptor)
+- [The `BluetoothCharacteristic` interface](#characteristic)
+  * `BluetoothCharacteristic` events
+    - [read](#onread)
+    - [write](#onwrite)
+    - [subscribe](#onsubscribe)
+    - [unsubscribe](#onunsubscribe)
+    - [error](#oncherror)
+  * `BluetoothCharacteristic methods
+    - [startNotifications()](#startnotifications)
+    - [startNotifications()](#stopnotifications)
+- [The `BluetoothCharacteristicRequest` interface](#characteristicrequest)
+  * `BluetoothCharacteristicRequest` methods
+    - [respond(data)](#respond)
+    - [error(error)](#errormethod)
+
+Introduction
+------------
+This API exposes Bluetooth Smart functionality for Bluetooth Smart Peripheral (BSP) mode. The terminology and context is taken from the [Bluetooth 4.2. specification](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439).
+
+A Bluetooth Smart Peripheral (BSP) device supports the following functionality:
+- Host a [GATT (Generic Attribute Profile)](https://www.bluetooth.com/specifications/gatt) server that exposes a hierarchy of [`Service`](#service), [`Characteristic`](#characteristic) and [`Descriptor`](#descriptor) objects.
+- Broadcast (advertise) information (e.g. services) using advertisment packets. Advertisement or Scan Response data packet is a 31 byte payload used to advertise the device's capabilities and connection parameters.
+- Accept connections from Bluetooth Smart devices in Central mode that can access its services exposed through the GAP, the [Generic Access Profile](https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile). A device has only one
+instance of the GAP service in the GATT server. The GAP service is a GATT
+based service with the service UUID as «GAP Service» defined in the
+[Bluetooth Assigned Numbers document](https://www.bluetooth.com/specifications/assigned-numbers).
+
+The [W3C Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth) API exposes functionality for Bluetooth Smart clients (Central mode).
+
+### Use cases
+
+This API is used by applications that implement a Bluetooth Peripheral device and expose sensorial data via Bluetooth.
+- Applications define the Bluetooth Smart services, characteristics and descriptors, then registers them with the implementation.
+- Applications can build Bluetooth advertisement packets, then start (and stop) advertising.
+- For the defined characteristics, applications should register event listeners for handling requests coming from clients. The event listeners receive the request, and should reply to them with appropriate data, or error code.
+
+<a name="apiobject">
+The API object
+--------------
+The API entry point is a [`BluetoothPeripheralDevice`](./#bpd) object that is exposed in a platform specific manner. As an example, on Node.js it can be obtained by requiring the package that implements this API. On other platforms, it can be constructed.
+
+```javascript
+var bpd = require('bluetooth-peripheral');
+```
+If the functionality is not supported by the platform, `require` should throw `NotSupportedError`. If there is no permission for using the functionality, `require` should throw `SecurityError`.
+
+<a name="bpd">
+### The `BluetoothPeripheralDevice` interface
+This object is created returned by `require`. It has the following read-only properties.
+
+| Property  | Type   | Optional | Default value | Represents |
+| ---       | ---    | ---      | ---           | ---        |
+| address   | String | no | `undefined` | Bluetooth Device Address |
+| addressType | String enum | no | `undefined` | Bluetooth Device Address Type |
+| name      | String | yes | `undefined` | the Bluetooth Device Name in scan responses |
+| enabled   | boolean | no | false | whether Bluetooth and this device is enabled |
+| services  | array of Service objects | no | [] | Primary services on this device |
+
+<a name="bd_addr">
+The `address` property is a 48 bit value (BD_ADDR) identifying a Bluetooth Smart device. On the UI level the Bluetooth address MUST be represented as 12 hexadecimal characters, possibly divided into sub-parts separated by ‘:’ (e.g., ‘000C3E3A4B69’ or ‘00:0C:3E:3A:4B:69’). On the UI level any number MUST have the most significant bit on left ordering.
+
+<a name="bd_addr_type">
+The `addressType` property can take the following values: `"public"`, `"static-random"`, `"private-resolvable"`, `"private"`.
+
+<a name="bd_name">
+The `name` property represents the Bluetooth device name that a Bluetooth device
+exposes to remote devices. It and can be up to 248 bytes encoded in UTF-8, therefore on the UI level it may be restricted to as few as 62 characters if codepoints outside the range U+0000 to U+007F are used. A device cannot expect that a general remote device is able to handle more than the first 40 characters of the Bluetooth device name. If a remote device has limited display capabilities, it may use only the first 20 characters.
+
+<a name="bd_enabled">
+The `enabled` property MUST be set to `true` if the Bluetooth Smart and the device is enabled, and otherwise to `false`.
+
+<a name="bd_services">
+The `services` property is a read-only array (sequence) of [`BluetoothService`](#service) objects that represents the primary GATT services on this device. A primary service is visible at device root level, and it may contain other services.
+
+#### `BluetoothPeripheralDevice` events
+
+| Event name        | Event callback argument |
+| --------------    | ----------------------- |
+| *enabledchange*   | N/A                     |
+| *connect*         | String (client Bluetooth Device Address) |
+| *disconnect*      | String (client Bluetooth Device Address) |
+| *error*           | Error                   |
+
+<a name="onenabledchange"></a>
+The `enabledchange` event is emitted when the [`enabled`](#bd_enabled) property is changed. Listeners should check the value of the `enabled` property.
+
+<a name="onconnect"></a>
+The `connect` event is emitted when a Bluetooth Smart device in Central mode (client) is connected. Listeners are invoked with the client's [Bluetooth Device Address](#bd_addr) as a string argument.
+
+<a name="ondisconnect"></a>
+The `disconnect` event is emitted when a connected client device is disconnected. Listeners are invoked with the client's [Bluetooth Device Address](#bd_addr) as a string argument.
+
+<a name="onerror"></a>
+The `error` event is emitted when a Bluetooth error needs to be reported to the application. Listeners are invoked with an [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object as argument.
+
+#### `BluetoothPeripheralDevice` methods
+
+<a name="enable"></a>
+##### The `enable()` method
+Requests enabling the device, and Bluetooth Smart functionality if needed, then returns.
+When the device is enabled, implementations should set the `enabled` property to `true` and emit the `enabledchange` event.
+
+<a name="disable"></a>
+##### The `disable()` method
+Requests disabling the device, then returns. When the device is disabled, implementations should set the `enabled` property to `false` and emit the `enabledchange` event.
+
+<a name="startadvertising"></a>
+##### The `startAdvertising(advertisement, options)` method
+Requests the platform to send Bluetooth Smart advertising packets initialized from the arguments.
+<a name="adv-options"></a>
+###### The `options` argument
+It is an object with the following properties:
+| Property  | Type   | Optional | Default value | Represents |
+| ---       | ---    | ---      | ---           | ---        |
+| connectable | boolean | yes | `true` | whether the device can be connected to |
+| minInterval | Number | yes | selected by the platform | minimum time interval between advertisements|
+| maxInterval | Number | yes | selected by the platform | maximum time interval between advertisements|
+
+The `connectable` advertisement option is `true` when the device is allowed to be connected by clients.
+
+The `minInterval` advertisement option tells the minimum time interval between consecutive advertisement packets in milliseconds. The value can be between 100 and 32000 milliseconds. Platforms may override this value.
+
+The `maxInterval` advertisement option tells the maximum time interval between consecutive advertisement packets in milliseconds. The value can be between 100 and 32000 milliseconds. Platforms may override this value.
+<a name="advertisement"></a>
+###### The `advertisement` argument
+Advertisement packet data can be of the following types:  string (e.g. flags), device name, transmit power, service UUID (16, 32, or 128 bit), service data, public or random target address, advertising interval, device address, Bluetooth Smart role, URI, or manufacturer data. Applications are expected to build the binary advertisement packets based on the Bluetooth specifications as a `Buffer` object. This API provides helpers for the most common data types. It is an object with properties described in the `startadvertising()` method steps.
+
+The `startadvertising()` method runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- If `options.connectable` is not `true`, then set `options.connectable` to `false`.
+- If `options.minInterval` is `undefined`, set `options.minInterval` to a platform default value. Otherwise, if it is a number, and it is smaller than 100 or bigger than 32000, reject `promise` with `TypeError`. Otherwise set `options.minInterval` to that value rounded down to the nearest value dividable by 100.
+- If `options.maxInterval` is `undefined`, set `options.maxInterval` to a platform default value. Otherwise, if it is a number, and it is smaller than 100 or bigger than 32000, reject `promise` with `TypeError`. Otherwise set `options.maxInterval` to that value rounded down to the nearest value dividable by 100.
+- If `advertisement` is not an object, reject `promise` with `TypeError`.
+- If `advertisement.scanResponse` is an object and `advertisement.scanResponse.name` is a string or `advertisement.scanResponse.date` is a [`Buffer`](../README.md/#buffer) object, then let `scanResponse` be `advertisement.scanResponse`.
+- If `advertisement.data` is a [`Buffer`](../README.md/#buffer) object, let `buffer` take that value.
+- Otherwise let `buffer` be an empty `Buffer`, and use the properties of `advertisement` (when defined) to prepare `buffer` based on the following properties of `advertisement`. The algorithm on how to prepare `buffer` is described in the Bluetooth specification, and the platform may have an API to support that.
+  * `uuids` is an array of Bluetooth UUID strings representing services; if specified, implementations SHOULD add them to the advertisement packet `buffer` compliant to the Bluetooth specification.
+  * `serviceData` is an object with two properties, a UUID string `uuid` and a `Buffer` object `data`. Implementations should add `uuid` and `data` to `buffer`, if there is sufficient space in the advertisement packet. If there is no space, skip to the next step.
+  * `manufacturerData` is an object with two properties, a number `manufacturerId` and a `Buffer` data. Implementations should add `manufacturerId` and `data` to `buffer`, if there is sufficient space in the advertisement packet. If there is no space, skip to the next step.
+  * `deviceClass` is a number. If specified, implementations should add it to `buffer`, if there is sufficient space in the advertisement packet. If there is no space, skip to the next step.
+  * `includeTxPower` is a boolean value. If `true`, then implementations should add the transmit power to the advertisement packet, if there is space. If not, skip to the next step.
+- Request the underlying platform to start sending the prepared advertisement packet `buffer` with the options specified in `options`. If the request fails, reject `promise` with an `Error` object `error` that has `error.message` set to `"BluetoothStartAdvertisement"`.
+- If the implementation can read the advertisement options used by the platform for this advertisement, set `options.minInterval` and `options.maxInterval` to the actual values used by the platform.
+- Resolve `promise` with `options`.
+
+<a name="stopadvertising"></a>
+##### The `stopAdvertising()` method
+Requests the platform to stop sending advertisement packets. It runs the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- Request from the underlying platform to stop the current advertisement.
+- If the request is unsuccessful, reject `promise` with an `Error` object `error` with `error.message` set to `"BluetoothStopAdvertisement"`.
+- Otherwise, if the request was successful, resolve `promise`.
+
+<a name="addservice"></a>
+##### The `addService(service)` method
+Adds a service to the internal slot representing the primary services. Returns `false` if `service` is not a valid [`BluetoothService`](#service) object, or if `service.primary` is `false`, or if `service.uuid` has already been added.
+
+<a name="removeservice"></a>
+##### The `removeService(service, recursive)` method
+Removes a service from the internal slot that represents the primary services of the device. Returns `false` if `service` is not a valid [`BluetoothService`](#service) object, or if `service.uuid` is not found in the internal slot of Bluetooth services. If `recursive` is `true`, then also remove all services in `service.includedServices` that are not used by any other service.
+
+<a name="service"></a>
+### The `BluetoothService` dictionary
+It is an object with the following properties.
+
+| Property  | Type   | Optional | Default value | Represents |
+| ---       | ---    | ---      | ---           | ---        |
+| uuid      | String | no       | `undefined`   | Bluetooth Service UUID |
+| primary   | boolean | no      | `false`       | whether primary (root) service |
+| characteristics | array of [`BluetoothCharacteristic`](#characteristic) objects | no | [] | Bluetooth characteristics |
+| includedServices | array of String | no | [] | list of UUIDs of included services |
+
+<a name="descriptor`"></a>
+### The `BluetoothDescriptor` dictionary
+It is an object with the following properties.
+
+| Property  | Type    | Optional | Default value | Represents |
+| ---       | ---     | ---      | ---           | ---        |
+| uuid      | String  | no       | `undefined`   | Bluetooth Descriptor UUID |
+| value     | String  | no       | `undefined`   | descriptor value |
+| flags     | array of String | no | [] | flags (Bluetooth "properties") |
+
+The `flags` property contains maximum 2 strings that can be either `"read"` or `"write"`.
+
+<a name="characteristic"></a>
+### The `BluetoothCharacteristic` interface
+It has the following read-only properties:
+
+| Property  | Type    | Optional | Default value | Represents |
+| ---       | ---     | ---      | ---           | ---        |
+| uuid      | String  | no       | `undefined`   | Bluetooth Descriptor UUID |
+| flags     | array of String | no | [] | flags (Bluetooth "properties") |
+| descriptors | array of objects | no | [] | Bluetooth descriptors |
+| notifying | boolean | no       | `undefined` | whether notifications are on |
+
+The `BluetoothCharacteristic` object can be constructed with a dictionary that can have any or all of the following properties of `BluetoothCharacteristic`: `uuid`, `flags`, `descriptors`.
+
+The `uuid` property is a string that represents a Bluetooth UUID.
+
+The `flags` property is an array of strings that can take the following values: `"read"`, `"write"`, `"notify"`.
+
+The `descriptors` property is an array of [`BluetoothDescriptor`](#descriptor) objects that describe this Bluetooth Characteristic.
+
+#### `BluetoothCharacteristic` events
+
+| Event name    | Event callback argument |
+| ------------  | ----------------------- |
+| *read*        | [`BluetoothCharacteristicRequest`](#request) |
+| *write*       | [`BluetoothCharacteristicRequest`](#request) |
+| *subscribe*   | [`BluetoothCharacteristicRequest`](#request) |
+| *unsubscribe* | [`BluetoothCharacteristicRequest`](#request) |
+| *error*       | `Error`                 |
+
+<a name="onread"></a>
+The `read` event is emitted when the device receives a request for reading a Characteristic.
+Listeners receive a [`BluetoothCharacteristicRequest`](#request) object as argument.
+...
+
+<a name="onwrite"></a>
+The `write` event is emitted when the device receives a request for writing a Characteristic.
+Listeners receive a [`BluetoothCharacteristicRequest`](#request) object as argument.
+...
+
+<a name="onsubscribe"></a>
+The `subscribe` event is emitted when the device receives a request for subscribing to notifications for a Characteristic.
+Listeners receive a [`BluetoothCharacteristicRequest`](#request) object as argument.
+...
+
+<a name="onunsubscribe"></a>
+The `subscribe` event is emitted when the device receives a request for unsubscribing to notifications for a Characteristic.
+...
+
+<a name="oncherror"></a>
+The `error` event is emitted when a Bluetooth error concerning operations with Characteristics needs to be reported to the application. Listeners are invoked with an [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object as argument.
+
+#### `BluetoothCharacteristic` methods
+
+<a name="startnotifications"></a>
+##### The `startNotifications()` method
+Requests the underlying platform to start sending notifications for this characteristic to all subscribed clients.
+
+<a name="stopnotifications"></a>
+##### The `stopNotifications()` method
+Requests the underlying platform to stop sending notifications for this characteristic.
+
+<a name="characteristicrequest"></a>
+### The `BluetoothCharacteristicRequest` interface
+
+Contains the following read-only properties:
+
+| Property  | Type    | Optional | Default value | Represents |
+| ---       | ---     | ---      | ---           | ---        |
+| source    | String  | no       | `undefined`   | client Bluetooth Device Address |
+| operation | String  | no       | `undefined`   | operation: read, write, notify |
+| data      | `Buffer` | yes     | `null`        | data |
+| offset    | number  | yes      | 0             | Offset in data` |
+| needsResponse | boolean | yes  | `true`        | whether response needs to be sent |
+
+The `source` property is a string representing the Bluetooth Device Address of the client.
+
+The `operation` property is a string that can take one of the following values: `"read"`, `"write"`, "`notify"`.
+
+The `data` property is a [`Buffer`](../README.md/#buffer) object that is not `null` for `"write"` operation, and `null` otherwise.
+
+The `offset` property is a positive number that specifies the byte offset in `data` pertaining to the operation (read or write).
+
+The `needsResponse` property is a boolean that is by default `true`.
+
+#### `BluetoothCharacteristicRequest` methods
+
+<a name="respond"></a>
+##### The `respond(data)` method
+Sends a response to the request. It executes the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- Create a response to the request, and include `data` in the response.
+- Request from the underlying platform to send the response to the client.
+- If the request is unsuccessful, reject `promise` with an `Error` object `error` with `error.message` set to `"BluetoothSendResponse"`.
+- Otherwise, if the request was successful, resolve `promise`.
+
+<a name="errormethod"></a>
+##### The `error(error)` method
+Sends an error response to the request. It executes the following steps:
+- Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
+- Create an error response to the request, and include `error` in the response.
+- Request from the underlying platform to send the response to the client.
+- If the request is unsuccessful, reject `promise` with an `Error` object `error` with `error.message` set to `"BluetoothSendErrorResponse"`.
+- Otherwise, if the request was successful, resolve `promise`.

--- a/api/ble/README.md
+++ b/api/ble/README.md
@@ -25,7 +25,7 @@ IoT Bluetooth Smart API
     - [error](#oncherror)
   * `BluetoothCharacteristic methods
     - [startNotifications()](#startnotifications)
-    - [startNotifications()](#stopnotifications)
+    - [stopNotifications()](#stopnotifications)
 - [The `BluetoothCharacteristicRequest` interface](#characteristicrequest)
   * `BluetoothCharacteristicRequest` methods
     - [respond(data)](#respond)
@@ -37,7 +37,7 @@ This API exposes Bluetooth Smart functionality for Bluetooth Smart Peripheral (B
 
 A Bluetooth Smart Peripheral (BSP) device supports the following functionality:
 - Host a [GATT (Generic Attribute Profile)](https://www.bluetooth.com/specifications/gatt) server that exposes a hierarchy of [`Service`](#service), [`Characteristic`](#characteristic) and [`Descriptor`](#descriptor) objects.
-- Broadcast (advertise) information (e.g. services) using advertisment packets. Advertisement or Scan Response data packet is a 31 byte payload used to advertise the device's capabilities and connection parameters.
+- Broadcast (advertise) information (e.g. services) using advertisement packets. Advertisement or Scan Response data packet is a 31 byte payload used to advertise the device's capabilities and connection parameters.
 - Accept connections from Bluetooth Smart devices in Central mode that can access its services exposed through the GAP, the [Generic Access Profile](https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile). A device has only one
 instance of the GAP service in the GATT server. The GAP service is a GATT
 based service with the service UUID as «GAP Service» defined in the
@@ -47,7 +47,7 @@ The [W3C Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth) API expo
 
 ### Use cases
 
-This API is used by applications that implement a Bluetooth Peripheral device and expose sensorial data via Bluetooth.
+This API is used by applications that implement a Bluetooth Peripheral device and expose sensor data via Bluetooth.
 - Applications define the Bluetooth Smart services, characteristics and descriptors, then registers them with the implementation.
 - Applications can build Bluetooth advertisement packets, then start (and stop) advertising.
 - For the defined characteristics, applications should register event listeners for handling requests coming from clients. The event listeners receive the request, and should reply to them with appropriate data, or error code.
@@ -58,9 +58,9 @@ The API object
 The API entry point is a [`BluetoothPeripheralDevice`](./#bpd) object that is exposed in a platform specific manner. As an example, on Node.js it can be obtained by requiring the package that implements this API. On other platforms, it can be constructed.
 
 ```javascript
-var bpd = require('bluetooth-peripheral');
+var btdevice = require('bluetooth-peripheral');
 ```
-If the functionality is not supported by the platform, `require` should throw `NotSupportedError`. If there is no permission for using the functionality, `require` should throw `SecurityError`.
+If the functionality is not supported by the platform, `require` should throw `NotSupportedError`. If the underlying platform doesn't allow using the functionality, `require` should throw `SecurityError`.
 
 <a name="bpd">
 ### The `BluetoothPeripheralDevice` interface
@@ -71,24 +71,24 @@ This object is created returned by `require`. It has the following read-only pro
 | address   | String | no | `undefined` | Bluetooth Device Address |
 | addressType | String enum | no | `undefined` | Bluetooth Device Address Type |
 | name      | String | yes | `undefined` | the Bluetooth Device Name in scan responses |
-| enabled   | boolean | no | false | whether Bluetooth and this device is enabled |
-| services  | array of Service objects | no | [] | Primary services on this device |
+| enabled   | boolean | no | false | whether Bluetooth is enabled |
+| services  | array of Service objects | no | [] | Primary services on the device |
 
 <a name="bd_addr">
-The `address` property is a 48 bit value (BD_ADDR) identifying a Bluetooth Smart device. On the UI level the Bluetooth address MUST be represented as 12 hexadecimal characters, possibly divided into sub-parts separated by ‘:’ (e.g., ‘000C3E3A4B69’ or ‘00:0C:3E:3A:4B:69’). On the UI level any number MUST have the most significant bit on left ordering.
+The `address` property is a 48 bit value (BD_ADDR) identifying a Bluetooth Smart device. On the UI level, the Bluetooth address MUST be represented as 12 hexadecimal characters, possibly divided into sub-parts separated by ‘:’ (e.g., ‘000C3E3A4B69’ or ‘00:0C:3E:3A:4B:69’). On the UI level, any number MUST have the most significant bit on left ordering.
 
 <a name="bd_addr_type">
-The `addressType` property can take the following values: `"public"`, `"static-random"`, `"private-resolvable"`, `"private"`.
+The `addressType` property can take the following values: `"public"`, `"static-random"`, `"private-resolvable"`, and `"private"`.
 
 <a name="bd_name">
 The `name` property represents the Bluetooth device name that a Bluetooth device
-exposes to remote devices. It and can be up to 248 bytes encoded in UTF-8, therefore on the UI level it may be restricted to as few as 62 characters if codepoints outside the range U+0000 to U+007F are used. A device cannot expect that a general remote device is able to handle more than the first 40 characters of the Bluetooth device name. If a remote device has limited display capabilities, it may use only the first 20 characters.
+exposes to remote devices. It is up to 248 bytes encoded as UTF-8, therefore on the UI level it may be restricted to as few as 62 characters if codepoints outside the range U+0000 to U+007F are used. A device cannot expect that a general remote device is able to handle more than the first 40 characters of the Bluetooth device name. If a remote device has limited display capabilities, it may use only the first 20 characters.
 
 <a name="bd_enabled">
-The `enabled` property MUST be set to `true` if the Bluetooth Smart and the device is enabled, and otherwise to `false`.
+The `enabled` property MUST be set to `true` if the Bluetooth Smart functionality is enabled on the device, and otherwise to `false`.
 
 <a name="bd_services">
-The `services` property is a read-only array (sequence) of [`BluetoothService`](#service) objects that represents the primary GATT services on this device. A primary service is visible at device root level, and it may contain other services.
+The `services` property is a read-only array (sequence) of [`BluetoothService`](#service) objects that represents the primary GATT services on the device. A primary service is visible at device root level, and it may contain other services.
 
 #### `BluetoothPeripheralDevice` events
 
@@ -100,16 +100,16 @@ The `services` property is a read-only array (sequence) of [`BluetoothService`](
 | *error*           | Error                   |
 
 <a name="onenabledchange"></a>
-The `enabledchange` event is emitted when the [`enabled`](#bd_enabled) property is changed. Listeners should check the value of the `enabled` property.
+The `enabledchange` event is emitted when the [`enabled`](#bd_enabled) property is changed. Event listeners should check the value of the `enabled` property.
 
 <a name="onconnect"></a>
-The `connect` event is emitted when a Bluetooth Smart device in Central mode (client) is connected. Listeners are invoked with the client's [Bluetooth Device Address](#bd_addr) as a string argument.
+The `connect` event is emitted when a Bluetooth Smart device in Central mode (client) is connected. Event listeners are invoked with the client's [Bluetooth Device Address](#bd_addr) as a string argument.
 
 <a name="ondisconnect"></a>
-The `disconnect` event is emitted when a connected client device is disconnected. Listeners are invoked with the client's [Bluetooth Device Address](#bd_addr) as a string argument.
+The `disconnect` event is emitted when a connected client device is disconnected. Event listeners are invoked with the client's [Bluetooth Device Address](#bd_addr) as a string argument.
 
 <a name="onerror"></a>
-The `error` event is emitted when a Bluetooth error needs to be reported to the application. Listeners are invoked with an [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object as argument.
+The `error` event is emitted when a Bluetooth error needs to be reported to the application. Event listeners are invoked with an [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object as argument.
 
 #### `BluetoothPeripheralDevice` methods
 
@@ -146,16 +146,16 @@ Advertisement packet data can be of the following types:  string (e.g. flags), d
 The `startadvertising()` method runs the following steps:
 - Return a [`Promise`](../README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
 - If `options.connectable` is not `true`, then set `options.connectable` to `false`.
-- If `options.minInterval` is `undefined`, set `options.minInterval` to a platform default value. Otherwise, if it is a number, and it is smaller than 100 or bigger than 32000, reject `promise` with `TypeError`. Otherwise set `options.minInterval` to that value rounded down to the nearest value dividable by 100.
-- If `options.maxInterval` is `undefined`, set `options.maxInterval` to a platform default value. Otherwise, if it is a number, and it is smaller than 100 or bigger than 32000, reject `promise` with `TypeError`. Otherwise set `options.maxInterval` to that value rounded down to the nearest value dividable by 100.
+- If `options.minInterval` is `undefined`, set `options.minInterval` to a platform default value. Otherwise, if it is a number, and it is smaller than 100 or bigger than 32000, reject `promise` with `TypeError`. Otherwise, set `options.minInterval` to that value rounded down to the nearest value dividable by 100.
+- If `options.maxInterval` is `undefined`, set `options.maxInterval` to a platform default value. Otherwise, if it is a number, and it is smaller than 100 or bigger than 32000, reject `promise` with `TypeError`. Otherwise, set `options.maxInterval` to that value rounded down to the nearest value dividable by 100.
 - If `advertisement` is not an object, reject `promise` with `TypeError`.
 - If `advertisement.scanResponse` is an object and `advertisement.scanResponse.name` is a string or `advertisement.scanResponse.date` is a [`Buffer`](../README.md/#buffer) object, then let `scanResponse` be `advertisement.scanResponse`.
 - If `advertisement.data` is a [`Buffer`](../README.md/#buffer) object, let `buffer` take that value.
-- Otherwise let `buffer` be an empty `Buffer`, and use the properties of `advertisement` (when defined) to prepare `buffer` based on the following properties of `advertisement`. The algorithm on how to prepare `buffer` is described in the Bluetooth specification, and the platform may have an API to support that.
+- Otherwise, let `buffer` be an empty `Buffer`, and use the properties of `advertisement` (when defined) to prepare `buffer` based on the following properties of `advertisement`. The algorithm on how to prepare `buffer` is described in the Bluetooth specification, and the platform may have an API to support that.
   * `uuids` is an array of Bluetooth UUID strings representing services; if specified, implementations SHOULD add them to the advertisement packet `buffer` compliant to the Bluetooth specification.
-  * `serviceData` is an object with two properties, a UUID string `uuid` and a `Buffer` object `data`. Implementations should add `uuid` and `data` to `buffer`, if there is sufficient space in the advertisement packet. If there is no space, skip to the next step.
-  * `manufacturerData` is an object with two properties, a number `manufacturerId` and a `Buffer` data. Implementations should add `manufacturerId` and `data` to `buffer`, if there is sufficient space in the advertisement packet. If there is no space, skip to the next step.
-  * `deviceClass` is a number. If specified, implementations should add it to `buffer`, if there is sufficient space in the advertisement packet. If there is no space, skip to the next step.
+  * `serviceData` is an object with two properties, a UUID string `uuid` and a `Buffer` object `data`. Implementations should add `uuid` and `data` to `buffer`, if there is sufficient space in the advertisement packet. If there is not sufficient space, skip to the next step.
+  * `manufacturerData` is an object with two properties, a number `manufacturerId` and a `Buffer` data. Implementations should add `manufacturerId` and `data` to `buffer`, if there is sufficient space in the advertisement packet. If there is not sufficient space, skip to the next step.
+  * `deviceClass` is a number. If specified, implementations should add it to `buffer`, if there is sufficient space in the advertisement packet. If there is not sufficient space, skip to the next step.
   * `includeTxPower` is a boolean value. If `true`, then implementations should add the transmit power to the advertisement packet, if there is space. If not, skip to the next step.
 - Request the underlying platform to start sending the prepared advertisement packet `buffer` with the options specified in `options`. If the request fails, reject `promise` with an `Error` object `error` that has `error.message` set to `"BluetoothStartAdvertisement"`.
 - If the implementation can read the advertisement options used by the platform for this advertisement, set `options.minInterval` and `options.maxInterval` to the actual values used by the platform.
@@ -249,7 +249,7 @@ The `subscribe` event is emitted when the device receives a request for unsubscr
 ...
 
 <a name="oncherror"></a>
-The `error` event is emitted when a Bluetooth error concerning operations with Characteristics needs to be reported to the application. Listeners are invoked with an [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object as argument.
+The `error` event is emitted when a Bluetooth error concerning operations with Characteristics needs to be reported to the application. Event listeners are invoked with an [`Error`](https://nodejs.org/api/errors.html#errors_class_error) object as argument.
 
 #### `BluetoothCharacteristic` methods
 

--- a/api/ble/webidl.md
+++ b/api/ble/webidl.md
@@ -16,7 +16,7 @@ interface BluetoothPeripheralDevice {
     boolean removeService(BluetoothUUID uuid, optional boolean recursive = false);
 
     void enable();
-    // void disable();
+    void disable();
 
     Promise<AdvertisingOptions> startAdvertising(Advertisement advertisement,
                                            optional AdvertisingOptions options);

--- a/api/ble/webidl.md
+++ b/api/ble/webidl.md
@@ -1,0 +1,140 @@
+Web IDL for Bluetooth Smart, Peripheral Mode
+============================================
+
+```javascript
+// require returns a BluetoothPeripheralDevice object
+// var ble = require("ble-peripheral");
+
+[NoInterfaceObject]
+interface BluetoothPeripheralDevice {
+    readonly attribute BluetoothDeviceAddress address;
+    readonly attribute BluetoothDeviceAddressType addressType;
+    readonly attribute String name;
+
+    readonly attribute sequence<Service> services;  // primary services
+    boolean addService(Service service);
+    boolean removeService(BluetoothUUID uuid, optional boolean recursive = false);
+
+    void enable();
+    // void disable();
+
+    Promise<AdvertisingOptions> startAdvertising(Advertisement advertisement,
+                                           optional AdvertisingOptions options);
+    Promise stopAdvertising();
+
+    readonly attribute boolean enabled;
+    attribute EventHandler onenabledchange;
+
+    attribute EventHandler<BluetoothDeviceAddress> onconnect;
+    attribute EventHandler<BluetoothDeviceAddress> ondisconnect;
+    attribute EventHandler<Error> onerror;
+};
+
+BluetoothPeripheralDevice implements EventEmitter;
+
+typedef (String or unsigned long long) BluetoothDeviceAddress;
+typedef String BluetoothUUID;
+
+enum BluetoothDeviceAddressType {
+    "public", "static-random", "private-resolvable", "private"
+};
+// private addresses are also random, but 'random-private-resolvable' is too long
+
+dictionary AdvertisingOptions {
+    boolean connectable = true;
+    unsigned long minInterval;  // 100..32000 ms; hint, platform may override
+    unsigned long maxInterval;  // 100..32000 ms; hint, platform may override
+};
+
+// - one raw Buffer for ad, and a scan response
+// - one ad built from 'uuids', .. txPower, if space allows
+
+dictionary AdvertisementData {
+    // if specified, used for scan response
+    ScanResponse scanResponse;
+
+    // raw advertisment data
+    Buffer data;  // if specified, use this and ignore the others
+
+    // or build advertisment data from the following properties, if defined
+    sequence<BluetoothUUID> uuids uuids;
+    ServiceDataAdvertisement serviceData;
+    ManufacturerAdvertisement manufacturerData;
+    unsigned long deviceClass;
+    boolean includeTxPower = false;
+};
+
+// advertisment can be a single raw Buffer or a structure
+typedef (AdvertisementData or Buffer) Advertisement;
+
+dictionary ScanResponse {
+    String name;  // may get overridden by the platform
+    Buffer data;  // may not be used by the platform
+};
+
+dictionary ManufacturerData {
+    unsigned long manufacturerId;
+    Buffer data;
+}
+
+disctionary ServiceData {
+    BluetoothUUID uuid;
+    Buffer data;
+}
+
+dictionary Service {
+    BluetoothUUID uuid;
+    boolean primary;
+    Characteristic[] characteristics;
+    BluetoothUUID[] includedServices;
+};
+
+dictionary Descriptor {
+    BluetoothUUID uuid;
+    String value;
+    GATTFlag[] flags;  // only "read" and "write"
+};
+
+dictionary CharacteristicInit {
+    BluetoothUUID uuid;
+    sequence<GATTFlag> flags;
+    sequence <Descriptor> descriptors;
+};
+
+[Constructor(CharacteristicInit init)]
+interface Characteristic {
+    readonly attribute BluetoothUUID uuid;
+    readonly attribute sequence<GATTFlag> flags;
+    readonly attribute sequence <Descriptor> descriptors;
+
+    void startNotifications();  // notify + indicate
+    void stopNotifications();
+    readonly attribute boolean notifying;
+
+    attribute EventHandler<Request> onread;
+    attribute EventHandler<Request> onwrite;
+
+    // platform may handle subscriptions automatically, without event hooks
+    attribute EventHandler<Request> onsubscribe;
+    attribute EventHandler<Request> onunsubscribe;
+
+    attribute EventHandler<Error> onerror;  // e.g. on indication fail
+};
+
+Characteristic implements EventEmitter;
+
+enum GATTFlag { "read", "write", "notify" };
+//
+
+interface Request {
+    readonly attribute BluetoothDeviceAddress source;
+    readonly attribute GATTFlag operation;
+    readonly attribute unsigned long offset = 0;
+    readonly attribute boolean needsResponse;
+    readonly attribute Buffer? data = null;
+
+    Promise respond(optional Buffer data);
+    Promise error(Error error);
+};
+
+```

--- a/api/board/README.md
+++ b/api/board/README.md
@@ -25,6 +25,7 @@ var board = require("iot-board-arduino101");  // example package name
 
 console.log("Connected to board " + board.name);
 ```
+If the functionality is not supported by the platform, `require` should throw `NotSupportedError`. If there is no permission for using the functionality, `require` should throw `SecurityError`.
 
 <a name="pin"></a>
 ### The `Pin` interface

--- a/api/board/README.md
+++ b/api/board/README.md
@@ -18,7 +18,7 @@ The API object
 The API entry point is a [`Board`](./#board) object that is exposed in a platform specific manner. As an example, on Node.js it can be obtained by requiring the package that implements this API. On other platforms, it can be constructed.
 
 ```javascript
-var board = require('iot-board');
+var board = require("iot-board-arduino101");  // example package name
 
 // Alternative
 // var board = new Board();  // provides an instance of the default board
@@ -65,9 +65,9 @@ Represents a hardware board. It contains an event handler for errors, and API me
 | [`onerror`](#onerror) | event | no | `undefined`   | event for errors |
 | [`pin()`](#getpin)| function | no | defined by implementation | get a Pin object |
 | [`pins()`](#getpins)| function | no | defined by implementation | get an array of board pin names |
-| [`aio()`](#aio)   | function | no | defined by implementation | get an AIOPin object |
+| [`aio()`](#aio)   | function | no | defined by implementation | get an AIO object |
 | [`gpio()`](#gpio) | function | no | defined by implementation | get a GPIO object |
-| [`pwm()`](#pwm)   | function | no | defined by implementation | get a PWMPin object |
+| [`pwm()`](#pwm)   | function | no | defined by implementation | get a PWM object |
 | [`i2c()`](#i2c)   | function | no | defined by implementation | request an I2C object |
 | [`spi()`](#spi)   | function | no | defined by implementation | request an SPI object |
 | [`uart()`](#uart) | function | no | defined by implementation | request an UART object |
@@ -107,13 +107,13 @@ Returns a [`GPIO`](./gpio.md/#gpio) object associated with the pin name or pin o
 
 <a name="aio"></a>
 ##### The `aio(options)` method
-Returns an [`AIOPin`](./aio.md/#aio) object associated with the pin name or pin options given in the `name` argument. It runs the following steps:
+Returns an [`AIO`](./aio.md/#aio) object associated with the pin name or pin options given in the `name` argument. It runs the following steps:
 - Let `board` be the object representing this board.
 - Run the internal [`AIO initialization`](./aio.md/#init) algorithm with `options` and `board` as argument and return its result. Rethrow any errors that occur.
 
 <a name="pwm"></a>
 ##### The `pwm(options)` method
-Returns a [`PWMPin`](./pwm.md/#pwm) object associated with the pin name or pin options given in the [`options`](./pwm.md/#pwmoptions) argument. It runs the following steps:
+Returns a [`PWM`](./pwm.md/#pwm) object associated with the pin name or pin options given in the [`options`](./pwm.md/#pwmoptions) argument. It runs the following steps:
 - Let `board` be the object representing this board.
 - Run the internal [`PWM initialization`](./pwm.md/#init) algorithm with `options` and `board` as argument and return its result. Rethrow any errors that occur.
 

--- a/api/board/aio.md
+++ b/api/board/aio.md
@@ -15,7 +15,7 @@ Implementations MAY also support an explicit constructor that runs the [`AIO ini
 
 ```javascript
 try {
-  var board = require("iot-board");
+  var board = require("iot-board-arduino101");
 
   // Configure AIO using the board
   var aio1 = board.aio("A1");

--- a/api/board/aio.md
+++ b/api/board/aio.md
@@ -52,6 +52,7 @@ Represents the properties and methods that expose AIO functionality. The `AIO` o
 | ---        | ---    | ---      | ---           | ---        |
 | `channel`  | unsigned long | yes   | `undefined` | numeric index of the analog pin |
 | `rateLimit` | unsigned long | yes   | 0 | minimum milliseconds between 'ondata' emits |
+| `precision` | unsigned long | yes | `undefined` | bit length of digital sample |
 | `read()`   | function | no | defined by implementation | asynchronous read of the pin |
 | `close()`  | function | no | defined by implementation | close the pin |
 | `onchange` | event | no       | `undefined`   | event for pin value change |
@@ -71,6 +72,8 @@ The `address` property inherited from [`Pin`](./README.md/#pin) is initialized b
 The `channel` property is initialized by implementation and provides the numeric index of the analog pin, e.g. it is 0 for pin `"A0"` and 5 for pin `"A5"`.
 
 The `rateLimit` property represents the minimum number of milliseconds between two emits of the `ondata` event. It is used as a hint from applications when initializing AIO pins, and the value is reflecting the capability of the platform (`undefined` when rate limitation is not supported).
+
+The `precision` property represents the bit length of the digital sample. It is usually 10 or 12 bits, depending on board.
 
 #### `AIO` methods
 

--- a/api/board/arduino101.md
+++ b/api/board/arduino101.md
@@ -1,21 +1,21 @@
-Board Supportfor Arduino 101
-============================
+Board Support for Arduino 101
+=============================
 
-This page defines the values returned by the [`Board.pins()`](./README.md/#getpins) method, and describes the pin mapping for the [`Board.pin()`](./README.md/#getpin) method, from board labels that are printed on the board to operating system specific values.
+This page defines the values returned by the [`Board.pins()`](./README.md/#getpins) method and describes the pin mapping for the [`Board.pin()`](./README.md/#getpin) method, from board labels that are printed on the board to operating system specific values.
 
 The board labels are described in the [Arduino 101](https://www.arduino.cc/en/Main/ArduinoBoard101) board documentation. Also, for each board pin, the [`supportedModes`](./README.md/#pin) property of each pin is described.
 
-The [Arduino 101](https://www.arduino.cc/en/Main/ArduinoBoard101) board has 20 I/O pins that operate at 3.3 V and can be configured as described by the following table.
+The [Arduino 101](https://www.arduino.cc/en/Main/ArduinoBoard101) board has 20 I/O pins that operate at 3.3V and can be configured as described by the following table.
 
 Pins 0 and 1 can be also configured to be used as UART, the port name is exposed as `uart0`.
 
-On GPIO pins (0..13) interrupts can be configured to be triggered on low value, high value, rising edge, and falling edge. Some of the GPIO pins can trigger interrupt on value *change* (pins 2, 5, 7, 8, 10, 11, 12, 13).
+On GPIO pins (0..13) interrupts can be configured to be triggered on low value, high value, rising edge and falling edge. Some of the GPIO pins can trigger interrupt on value *change* (pins 2, 5, 7, 8, 10, 11, 12, 13).
 
-Pins 3,5,6 and 9 can be used for PWM output. These pins are marked on the board by a ~ (tilde) symbol next to the pin numbers. Pin 3 corresponds to PWM channel 0, pin 9 to PWM channel 3, etc.
+Pins 3, 5, 6 and 9 can be used for PWM output. These pins are marked on the board by a ~ (tilde) symbol next to the pin numbers. Pin 3 corresponds to PWM channel 0, pin 9 to PWM channel 3, etc.
 
-Pins (A0 - A5) can be used for analog input, and each provide 10 bits of resolution (i.e. 1024 different values).
+Pins A0 to A5 can be used for analog input and each provide 10 bits of resolution (i.e. 1024 different values).
 
-There are 3 LEDs on the board that can be accessed by the pin names `"LED0"`, `"LED1"`, and `"LED3"`.
+There are 3 LEDs on the board that can be accessed by the pin names `"LED0"`, `"LED1"` and `"LED3"`.
 
 Other names:
 - UART on pin 0 and 1 can be accessed by the name `"uart0"`.

--- a/api/board/gpio.md
+++ b/api/board/gpio.md
@@ -1,7 +1,7 @@
 GPIO API
 ========
 
-The GPIO API supports digital I/O pins.
+The GPIO (General Purpose Input & Output) API supports digital pins.
 
 The API object
 --------------
@@ -13,7 +13,7 @@ Implementations MAY also support an explicit constructor that runs the [`GPIO in
 
 ```javascript
 try {
-  var board = require("iot-board");
+  var board = require("iot-board-arduino101");
 
   // Configure GPIO using the board
   var gpio3 = board.gpio(3);  // GPIO input pin with default configuration.

--- a/api/board/i2c.md
+++ b/api/board/i2c.md
@@ -15,16 +15,17 @@ I2C functionality is exposed by the [`I2C`](#i2c) object that can be obtained by
 ```javascript
 try {
   var board = require("iot-board");
+  var i2c = null;
 
-  board.i2c().then(function(i2c) {
+  board.i2c().then(function(iic) {
+    i2c = iic;
     console.log("I2C bus " + i2c.bus + " opened with bus speed " + i2c.speed);
-    i2c.write(0x02, [1, 2, 3]).then(function() {
-      i2.read(0x03, 3).then(function(buffer) {
-        // Buffer object
-        console.log("From I2C device 0x03: " + buffer.toString());
-        i2c.close();
-      });
-    });
+    return i2c.write(0x02, [1, 2, 3])
+  }).then(function() {
+    return i2c.read(0x03, 3);
+  }).then(function(buffer) {
+      console.log("From I2C device 0x03: " + buffer.toString());
+      i2c.close();
   }).catch(function(err) {
     console.log("I2C error: " + err.message);
   });

--- a/api/board/i2c.md
+++ b/api/board/i2c.md
@@ -14,7 +14,7 @@ I2C functionality is exposed by the [`I2C`](#i2c) object that can be obtained by
 
 ```javascript
 try {
-  var board = require("iot-board");
+  var board = require("iot-board-arduino101");
   var i2c = null;
 
   board.i2c().then(function(iic) {

--- a/api/board/pwm.md
+++ b/api/board/pwm.md
@@ -18,7 +18,7 @@ Implementations MAY also support an explicit constructor that runs the [`PWM ini
 
 ```javascript
 try {
-  var board = require("iot-board");
+  var board = require("iot-board-arduino101");
 
   var pwm6 = board.pwm(6);  // configure pin 6 as PWM
   // Alternatives:

--- a/api/board/spi.md
+++ b/api/board/spi.md
@@ -12,7 +12,7 @@ SPI functionality is exposed by the [`SPI`](#spi) object that can be obtained by
 
 ```javascript
 try {
-  var board = require("iot-board");
+  var board = require("iot-board-arduino101");
 
   board.spi().then(function(spi) {
     console.log("SPI bus " + spi.bus + " opened with bus speed " + spi.speed);

--- a/api/board/uart.md
+++ b/api/board/uart.md
@@ -10,7 +10,7 @@ UART functionality is exposed by the [`UART`](#uart) object that can be obtained
 
 ```javascript
 try {
-  var board = require("iot-board");
+  var board = require("iot-board-arduino101");
 
   board.uart("serialUSB0").then(function(uart) {
     console.log("UART port " + uart.port);

--- a/api/board/webidl.md
+++ b/api/board/webidl.md
@@ -39,7 +39,7 @@ dictionary GPIOOptions {
     PinMode mode = "input";
     boolean activeLow = false;
     String edge = "any";  // "none", "rising", "falling", "any"
-    String pull = "none"; // "none", "pullup", "pulldown"
+    String pull = "none"; // "none", "pull-up", "pull-down"
 };
 
 [Constructor(GPIOOptions options, optional Board board)]
@@ -79,30 +79,28 @@ dictionary PWMOptions {
 interface PWM: Pin {
     readonly attribute unsigned long channel;
     readonly attribute boolean reversePolarity;
-    // 'value' returns PWMData
-    void write(PWMData value);
+    // 'value' returns PWMOptions
+    void write(PWMOptions value);
     void stop();
     void close();
 };
 
-dictionary PWMData {
+dictionary PWMOptions {
   double period;
   double pulseWidth;
   double dutyCycle;
 };
 
 // I2C
-enum I2CSpeed { "10kbps", "100kbps", "400kbps", "1000kbps", "3400kbps" };
-
 dictionary I2COptions {
   octet bus;
-  I2CSpeed speed;
+  unsigned long speed;  // 10, 100, 400, 1000, 3400 kbps
 };
 
 [NoInterfaceObject]
 interface I2C {
   readonly attribute octet bus;
-  readonly attribute I2CBusSpeed speed;
+  readonly attribute unsigned long speed;
 
   Promise<Buffer> read(octet device, unsigned long size);
   Promise write(octet device, Buffer data);

--- a/api/board/webidl.md
+++ b/api/board/webidl.md
@@ -60,10 +60,13 @@ dictionary AIOOptions {
 
 [Constructor( (PinName or AIOOptions) pin, optional Board board)]
 interface AIO: Pin {
-    unsigned long channel;  // analog channel
-    unsigned long rateLimit;     // rate limit for ondata
+    readonly attribute unsigned long channel;  // analog channel
+    readonly attribute unsigned long rateLimit;     // rate limit for ondata
+    readonly attribute unsigned long precision;  // 10 or 12 bits
+
     Promise<unsigned long> read();  // one-shot async read
     void close();
+
     attribute EventHandler<unsigned long> ondata;
 };
 

--- a/api/eventobserver.md
+++ b/api/eventobserver.md
@@ -2,30 +2,33 @@
 Event Observers
 ===============
 
-This is a proposal for a minimal event handling interface based on watches that monitor, filter and handle events in IoT use cases. It can be implemented with minimal polyfill on top of `EventTarget` or `EventEmitter`, in browser, Node.js and constrained runtimes.
-
-Based on use cases and issues from the [W3C Generic Sensor API](https://github.com/w3c/sensors/issues/21), the [W3C Web of Things](https://github.com/w3c/wot/issues/235),  and [Node.js style events](https://nodejs.org/api/events.html#events_events), it seems there are divergent views on how (sensor reading) events should be handled in IoT.
+This is a proposal for extending `EventEmitter` with filtering support, named `EventObserver`. It can be implemented with minimal polyfill on top of `EventEmitter` or `EventTarget`, in browser, Node.js and constrained runtimes.
 
 [Observables](https://github.com/tc39/proposal-observable) are also a proposed model to handle asynchronous samples streams. [Xstream](https://github.com/staltz/xstream) is also targeting similar use cases. Even though there is a lot of overlap, these seem to be slightly different use cases than the one in IoT implementations.
 
 The minimum feature set needed in IoT:
-- Event emitters with multiple event listeners (= streams).
-- Functionality for adding listeners.
-- Functionality for removing listeners.
 - Optional filters on events.
+- At least one event listener (server side), or multiple listeners (client side).
+- Add and remove listeners.
+- cancel observation.
 
-An `event` for IoT may need to contain the following informations:
+That is close to `EventTarget` or `EventListener` with the added functionality of supporting optional event filters.
+
+An event for IoT may need to contain the following information:
 - event name
-- data representation, including
+- data representation as a dictionary, including
   * timestamp
   * data origin
   * other properties from the data model.
 
-Another requirement would be that client code written in browser should be compatible with Node.js clients and also with constrained JS runtimes.
-
 The best existing structure to fulfill these requirements would be [EventSource](https://developer.mozilla.org/en/docs/Web/API/EventSource), see also a [Node.js implementation](https://www.npmjs.com/package/eventsource). However, it carries too many things for constrained implementations.
 
-The following proposal distillates the most needed features in a minimal package; it inherits `EventEmitter`, implements `EventTarget` for compatibility, and overloads the `on()` method to return a watch that is used in a manner similar to `Subscription` in [Observables](https://github.com/tc39/proposal-observable).
+ The main features of the proposed `EventObserver` are:
+- inherits `EventEmitter`
+- implements `EventTarget` for compatibility
+- overloads the `on()` method to accept an optional filter argument
+- adds convenience functions to add a filter, list filters, and replace the listener
+- returns a reference to itself for chaining.
 
 Web IDL
 =======
@@ -33,41 +36,22 @@ Web IDL
 
 EventObserver: EventEmitter {
   // 'on()' now takes an optional filter and returns a watch
-  EventWatch on(String eventName,
-                optional EventHandler listener,
+  EventObserver on(String eventName,
+                optional Function listener,
                 optional Filter filter);
+  void cancel(String eventName);  // remove filters and listener for an event
+  EventObserver filter(Filter filter);  // append a new filter, return `this`
+  EventObserver listener(EventHandler listener);  // replace listener
+
+  readonly attribute sequence<Filter> filters;
 };
 
 EventObserver implements EventTarget;
 // addEventListener, removeEventListener, dispatchEvent
 
-interface EventWatch {
-  void cancel();  // remove all filters and listener and cancel this watch
-
-  // syntactic sugar for managing filters and listener
-  EventWatch filter(Filter filter);  // append a new filter, return `this`
-  void listener(EventHandler listener);  // replace listener
-};
-
 callback EventFilter = boolean (any data);
 
 typedef (Dictionary or EventFilter) Filter;
-```
-
-A practical application would be reporting sensor data.
-
-```javascript
-interface SensorData {
-  readonly attribute String timestamp;
-  readonly attribute String origin;  // the URL of the data source
-  // ... other properties, according to the data model
-};
-
-[Constructor (String name, optional SensorData data)]
-interface SensorEvent: Event {
-  readonly attribute SensorData data;
-};
-
 ```
 
 Using `EventObserver`
@@ -75,25 +59,24 @@ Using `EventObserver`
 
 Objects that normally implement `EventTarget` or `EventEmitter`, will implement `EventObserver` instead, and will expose event names normally as `EventHandler` properties.
 
-Listeners are added to events as before, only that `on()` now returns an `EventWatch` object instead of `EventEmitter` self reference, so we lose cascading (of course, `EventWatch` could extend `EventEmitter` to solve that, but not in this version).
+Listeners are added to events as before, only that `on()` now returns an `EventObserver` self-reference instead of `EventEmitter` self reference.
 
 Also, `on()` will accept an optional filter, either a dictionary where all properties must match a property in event data, or a filter function that receives event data and returns `true` or `false`.
 
-The returned `EventWatch` object always refers to one event, has one listener, 0 or more filters, and exposes:
-- a `cancel()` function for the watch, that removes all filters and the listener,
-- a method to append a new filter to the watch,
-- a method to change the listener associated to the watch.
+When a filter is a function, it receives the same arguments as listeners.
 
-When a filter is a function, receives the same arguments as listeners.
-When a filter is a dictionary, the listener MUST receive only one argument that is an object, and each property found in the filter MUST value-match a property with the same name in the argument object in order that the listener is invoked.
+When a filter is a dictionary, the listener receives only one argument that is an object, and each property found in the filter is a value-match a property with the same name in the argument object.
 
-When a new filter is appended to the watch, it is applied after the previous filters, so it restricts more and more the invocation of the event listener.
+When a new filter is appended to the watch, it is applied after the previous filters, so it restricts more and more the invocation of the event listener ('AND' semantics).
 
-Since a listener can be added or changed in a watch, the listener parameter to the `on()` method becomes optional. A watch without a listener just doesn't work, i.e. it does not invoke any listener, until one is added.
+Since a listener can be added or changed later, the listener parameter to the `on()` method becomes optional.
 
-Note that the filtering functionality could be part of the listeners themselves, and then `EventObserver` would be reduced to `EventEmitter`. However, in IoT, using watches brings added value for cancellation, clarity with explicit cumulative filters, and flexibility with replaceable listeners.
+Filtering functionality could be part of the listeners implementations themselves, and then `EventObserver` would be reduced to `EventEmitter`. Then `EventObserver` is the same as `EventEmitter`.
 
-Also note that watches are only supported by the overloaded `on()` method of `EventEmitter`, and `EventTarget` is supported in [compatibility mode](#eventtarget).
+Code written with `EventEmitter` is compatible with `EventObserver`.
+
+If `EventObserver` is not implemented, then code written with `EventObserver` will work with events and listeners, but filters won't work, therefore filters need to be implemented inside listeners.
+
 
 How `EventObserver` is used in specifications:
 ```javascript
@@ -110,7 +93,7 @@ And how is it used in client code:
 ```javascript
 var obj = new MyObject();
 
-watch = obj.on("change")
+obj.on("change")
   .filter(function(data) {
     if (data.threshold > 0)
       return true;
@@ -119,46 +102,77 @@ watch = obj.on("change")
     // now it is guaranteed that data.threshold > 0
 )
 
-// ...
-
-watch.cancel();
-
 // alternative syntax, without filter
-watch = obj.on("change", function(data) {
+obj.on("change", function(data) {
   // use data;
   console.log("Timestamp: " + data.timestamp);
   console.log("Origin: " + data.origin);
 });
 
 // alternative syntax, with data filter
-watch = obj.on("change", function(data) {
-  // use data;
-}, { value: 0 });  // will trigger only when data.value is 0
+obj.on("change",
+        function(data) {
+          // use data;
+        },
+        { value: 0 });  // will trigger only when data.value is 0
 
+obj.cancel("change");
 ```
 
-<a name="promise"></a>
-`EventTarget` compatibility
-===========================
-In constrained runtimes it is recommended to support the following [EventTarget](https://developer.mozilla.org/en/docs/Web/API/EventTarget) methods:
-- the [`addEventListener(eventName, listener)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) method
-- the [`removeEventListener(eventName, listener)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener) method
-- the [`dispatchEvent(event)`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent) method
-- note that listeners receive an [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) object, following the semantics of `EventTarget`(https://developer.mozilla.org/en/docs/Web/API/EventTarget)
-- the [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) objects MUST contain at least the following properties:
-  * [`Event.type`](https://developer.mozilla.org/en-US/docs/Web/API/Event/type)
-  * [`Event.cancelable`](https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable), with the default value `false`
-  * [`Event.bubbles`](https://developer.mozilla.org/en-US/docs/Web/API/Event/bubbles), with the default value `false`
-  * [`Event.eventPhase`](https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase).
+Applications
+============
+
+## Discovery
+```javascript
+partial interface ThingClient: EventObserver {
+    EventObserver discover(Dictionary filter);
+    attribute EventHandler ondiscovery;
+};
+
+dictionary DiscoveryFilter {
+    // Thing properties
+};
+```
+It would be used like:
 
 ```javascript
+client.discover({ type: "lightSensor" })  // sets filter for EventObserver
+  .on("discovery", function(thing) {  // sets listener for EventObserver
+      console.log("Thing: " + thing.toString());
+  }).on("error", function(error)) {  // sets specific discovery error listener for EventObserver
+     console.log("Discovery error: " + error.message);
+  };
+```
 
-var obj = new MyObject();
+## Reporting sensor data
 
-obj.addEventListener("change", function(event) {
-  // use event.data as listeners receive an Event object
-  console.log("Timestamp: " + event.data.timestamp);
-  console.log("Origin: " + event.data.origin);
+```javascript
+interface SensorData {
+  readonly attribute String timestamp;
+  readonly attribute String origin;  // the URL of the data source
+  // ... other properties, according to the data model
+};
+
+[Constructor (String name, optional SensorData data)]
+interface SensorEvent: Event {
+  readonly attribute SensorData data;
+};
+
+interface Sensor: EventObserver {
+  attribute EventHandler ondata;
+}
+
+```
+Used as
+```javascript
+var s = new Sensor();
+
+s.on("data")
+.filter(function(data){
+    if (data.value > 1)
+      return true;
+    return false;
+}).listener(function(data) {
+  console.log("Data: " + data.value);
 });
-
 ```

--- a/api/ocf/README.md
+++ b/api/ocf/README.md
@@ -38,6 +38,7 @@ The API object is exposed in a platform specific manner. As an example, on Node.
 let module = 'ocf';  // use your own implementations' name
 var ocf = require(module);
 ```
+If the functionality is not supported by the platform, `require` should throw `NotSupportedError`. If there is no permission for using the functionality, `require` should throw `SecurityError`.
 
 When `require` is successful, it MUST return an object with the following read-only properties:
 - `client` is an object that implements the [OCF Client API](./client.md).

--- a/api/ocf/README.md
+++ b/api/ocf/README.md
@@ -1,10 +1,13 @@
 OCF Web API
 ===========
 
-* [Introduction](#introduction)
 * [OCF API object](#api-entry-point)
   - [OCF Client API](./client.md)
   - [OCF Server API](./server.md)
+* [Helper structures](#structures)
+  - The [OcfDevice](#ocfdevice) dictionary
+* - The [OcfPlatform](#ocfplatform) dictionary
+* - The [OcfError](#ocferror) interface
 * [Web IDL](./webidl.md)
 * [Examples](./examples.md)
 
@@ -27,7 +30,8 @@ Resources can be accessed remotely, and can notify subscribers with data and sta
 
 The devices support installable software modules called *applications*. This API is exposed on an OCF device and enables writing the applications that implement resources and business logic.
 
-## API entry point
+The API object
+--------------
 The API object is exposed in a platform specific manner. As an example, on Node.js it can be obtained by requiring the package that implements this API. On other platforms, it can be exposed as a property of a global object.
 
 ```javascript

--- a/api/ocf/client.md
+++ b/api/ocf/client.md
@@ -1,6 +1,29 @@
 Client API
 ==========
 
+- The [Resource](#resource) interface
+  * The [update](#onresourceupdate) event
+  * The [delete](#onresourcelost) event
+- Client events
+  * [platformfound](#onplatformfound)
+  * [devicefound](#ondevicefound)
+  * [devicelost](#ondevicelost)
+  * [resourcefound](#onresourcefound)
+  * [error](#onerror)
+- Discovery methods
+  * [getPlatformInfo(deviceId)](#getplatforminfo)
+  * [getDeviceInfo(deviceId)](#getdeviceinfo)
+  * [findPlatforms(listener)](#findplatforms)
+  * [findDevices(listener)](#finddevices)
+  * [findResources(options, listener)](#findplatforms)
+- Client methods
+  * [create(target, resourceInit)](#create)
+  * [retrieve(resourceId, options, listener)](#retrieve)
+  * [update(resource)](#update)
+  * [delete(resourceId)](#delete)
+
+Introduction
+------------
 The OCF Client API implements CRUDN (Create, Retrieve, Update, Delete, Notify) functionality that enables remote access to resources in the network, as well as OCF discovery.
 
 The Client API object does not expose its own properties, only events and methods.
@@ -180,7 +203,8 @@ The method runs the following steps:
 - If the `listener` argument is specified, add it as a listener to the [`resourcefound`](#resourcefound) event.
 - When a resource is discovered, fire a `resourcefound` event that contains a property named `resource`, whose value is a [`Resource`](#resource) object.
 
-## 4. CRUDN Methods
+<a name="client-methods"></a>
+## 4. Client methods
 <a name="create"></a>
 ##### 4.1. The `create(target, resourceInit)` method
 - Creates a remote resource on a given device. The device's [`create`](./server.md/#oncreate) event handler takes care of dispatching the request to the resource that will handle it, and responds with the created resource, or with an error.

--- a/api/ocf/client.md
+++ b/api/ocf/client.md
@@ -128,8 +128,6 @@ client.on('error', function(error) {
 ##### 3.1. The `getPlatformInfo(deviceId)` method
 Fetches a remote platform information object.  The `deviceId` argument is a string that contains an OCF device UUID. The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
 - Send a direct discovery request `GET /oic/p` with the given `deviceId` (which can be either a device UUID or a device URL, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, resolve `promise` with a [`Platform`](./README.md/#platform) object created from the response.
@@ -138,8 +136,6 @@ Fetches a remote platform information object.  The `deviceId` argument is a stri
 ##### 3.2. The `getDeviceInfo(deviceId)` method
 Fetches a remote device information object. The `deviceId` argument is a string that contains an OCF device UUID. The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a direct discovery request `GET /oic/d` with the given `deviceId`, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, resolve `promise` with a [`Device`](./README.md/#device) object created from the response.
@@ -152,8 +148,6 @@ Fetches a remote device information object. The `deviceId` argument is a string 
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a multicast request for retrieving `/oic/p` and wait for the answer.
 - If sending the request fails, reject `promise` with `"NetworkError"`, otherwise resolve `promise`.
 - If there is an error during the discovery protocol, fire an `error` event.
@@ -168,8 +162,6 @@ The method runs the following steps:
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `SecurityError`.
-- If the functionality is not supported, reject `promise` with `NotSupportedError`.
 - Send a multicast request for retrieving `/oic/d` and wait for the answer.
 - If sending the request fails, reject `promise` with `"NetworkError"`, otherwise resolve `promise`.
 - If there is an error during the discovery protocol, fire an `error` event.
@@ -192,8 +184,6 @@ The method runs the following steps:
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `SecurityError`.
-- If the functionality is not supported, reject `promise` with `NotSupportedError`.
 - Configure an OCF resource discovery request as follows:
   - If `options.deviceId` is specified, make a direct discovery request to that device
   - If `options.resourceType` is specified, include it as the `rt` parameter in a new endpoint multicast discovery request `GET /oic/res` to "All CoAP nodes" (`224.0.1.187` for IPv4 and `FF0X::FD` for IPv6, port `5683`).
@@ -221,8 +211,6 @@ The method sends a request to the device specified in `target` and the device's 
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to create the resource described by `resourceInit` to the device specified by `target.deviceId` and the handler resource on the device specified by `target.resourcePath`. Wait for the answer.
 - If there is an error during the request, reject `promise` with that error, otherwise resolve `promise`.
 
@@ -238,8 +226,6 @@ In the OCF retrieve request it is possible to set an `observe` flag if the clien
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Let `observe` be `null`.
 - If the `listener` argument is specified, add it as a listener to the `Resource` [`update`](#onresourceupdate) event, and set `observe` to `true`.
 - Let `resource` be the resource identified by `resourceId`.
@@ -258,8 +244,6 @@ The method runs the following steps:
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to update the resource specified by `resource` with the properties present in `resource`, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error, otherwise resolve `promise`.
 
@@ -271,7 +255,5 @@ The method runs the following steps:
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to delete the resource specified by `resourceId`, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error, otherwise resolve `promise`.

--- a/api/ocf/server.md
+++ b/api/ocf/server.md
@@ -273,8 +273,6 @@ See the [example](#exampleoncreate) for the `create` event.
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to register the given `resource`, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, update `resource` to be a [`Resource`](./client.md/#resource) object.
@@ -299,8 +297,6 @@ server.unregister(resource)
 ```
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to unregister the given `resourceId`, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, resolve `promise`.
@@ -317,8 +313,6 @@ See the [example](#exampleonupdate) for the `update` event.
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - For each client that requested observing `resource.resourceId`, do the following sub-steps:
     * If there were request options specified with the retrieve request associated with observing the resource, and if a [translate function](#translate) has been defined for the resource during its [registration](#register), then let `resource` be the result of invoking that translate function with `resource` and the [request options dictionary](#requestoptions) that has been saved for the [observation request](#onretrieve).
     * Send an OCF notification for `resource`, and wait for the answer.
@@ -334,8 +328,6 @@ Note that the `notify()` method always resolves. Errors on notifying individual 
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to enable presence for the current device, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, resolve `promise`.
@@ -347,8 +339,6 @@ The method runs the following steps:
 
 The method runs the following steps:
 - Return a [`Promise`](./README.md/#promise) object `promise` and continue [in parallel](https://html.spec.whatwg.org/#in-parallel).
-- If there is no permission to use the method, reject `promise` with `"SecurityError"`.
-- If the functionality is not supported, reject `promise` with `"NotSupportedError"`.
 - Send a request to disable presence for the current device, and wait for the answer.
 - If there is an error during the request, reject `promise` with that error.
 - When the answer is received, resolve `promise`.

--- a/api/ocf/server.md
+++ b/api/ocf/server.md
@@ -98,21 +98,21 @@ server.on('create', function(request) {
   let res = _createResource(request.target.resourcePath, request.resource);
 
   // Use oneiota.org RAML definitions, the request options, and sensor documentation.
-  var translate = function (resource, requestOptions) {
-      if ("oic.r.temperature" in resource.resourceTypes) {
+  var translate = function (representation, requestOptions) {
         switch (requestOptions.units) {
           case "C" :
-            resource.properties.temperature = _getCelsiusFromSensor(resource);
+            // use sensor specific code to get Celsius units
+            representation.temperature = _getCelsiusFromSensorT1();
             break;
           case "F":
-            resource.properties.temperature = _getFahrenheitFromSensor(resource);
+            representation.temperature = _getFahrenheitFromSensorT1();
             break;
           case "K":
-            resource.properties.temperature = _getKelvinFromSensor(resource);
+            representation.temperature = _getKelvinFromSensorT1();
             break;
         }
       }
-      return resource;
+      return representation;
   }
 
   // Register the new resource and then respond to the request.
@@ -216,7 +216,7 @@ server.on('delete', function(request) {
 | `resourceTypes` | array of strings | no       | `undefined`   | List of OCF resource types |
 
 <a name="translate"></a>
-- the `translate` argument is a function that is invoked by the implementation when the client requests a certain representation of the resource by the means of request options. The function takes two arguments, a `resource` object, and a dictionary that contains the request options. It returns the resource object with modified resource representation (`resource.properties`).
+- the `translate` argument is a function that is invoked by the implementation when the client requests a certain representation of the resource by the means of request options. The function takes two arguments, a resource `representation` object that comes from `resource.properties`, and a dictionary that contains the REST request options parsed into a dictionary. It returns the modified resource representation object.
 
 See the [example](#exampleoncreate) for the `create` event.
 

--- a/api/ocf/webidl.md
+++ b/api/ocf/webidl.md
@@ -124,7 +124,8 @@ dictionary ResourceInit {
 };
 
 interface OcfServer {
-  Promise<Resource> register(ResourceInit resource);
+  Promise<Resource> register(ResourceInit resource,
+                             optional TranslateFunction translate);
   Promise<void> unregister(ResourceId resource);
 
   // handle CRUDN requests from clients
@@ -147,6 +148,10 @@ interface OcfServer {
 };
 
 OCFServer implements EventEmitter;
+
+// The function that is called by implementation to select resource representation.
+callback TranslateFunction =  ResourceRepresentation (Resource resource,
+                                                      Dictionary requestOptions);
 
 // The request types below hide the request id, source, and target (this) deviceId.
 

--- a/api/ocf/webidl.md
+++ b/api/ocf/webidl.md
@@ -125,7 +125,7 @@ dictionary ResourceInit {
 
 interface OcfServer {
   Promise<Resource> register(ResourceInit resource,
-                             optional TranslateFunction translate);
+                             optional TranslateCallback translate);
   Promise<void> unregister(ResourceId resource);
 
   // handle CRUDN requests from clients
@@ -150,8 +150,9 @@ interface OcfServer {
 OCFServer implements EventEmitter;
 
 // The function that is called by implementation to select resource representation.
-callback TranslateFunction =  ResourceRepresentation (Resource resource,
-                                                      Dictionary requestOptions);
+callback TranslateCallback =
+    ResourceRepresentation (ResourceRepresentation representation,
+                            Dictionary requestOptions);
 
 // The request types below hide the request id, source, and target (this) deviceId.
 

--- a/api/ocf/webidl.md
+++ b/api/ocf/webidl.md
@@ -142,9 +142,6 @@ interface OcfServer {
   // enable/disable presence for this device
   Promise<void> enablePresence(optional unsigned long timeToLive);  // in ms
   Promise<void> disablePresence();
-
-  // Reply to a given request
-  Promise<void> respond(OcfRequest request, Error? result, optional Resource? resource);
 };
 
 OCFServer implements EventEmitter;
@@ -156,11 +153,16 @@ callback TranslateCallback =
 
 // The request types below hide the request id, source, and target (this) deviceId.
 
-dictionary OcfRequest {
-  ResourceId source;
-  ResourceId target;
-  USVString requestId;
-  ResourceId resource;
+[NoInterfaceObject]
+interface OcfRequest {
+  readonly attribute ResourceId source;
+  readonly attribute ResourceId target;
+  readonly attribute USVString requestId;
+  readonly attribute ResourceId resource;
+
+  // Reply to a given request
+  Promise<void> respond(optional Resource? resource);
+  Promise<void> error(Error error);
 }
 
 ```

--- a/api/sensors/README.md
+++ b/api/sensors/README.md
@@ -16,15 +16,41 @@ This API takes interface definitions for the following objects from the [W3C Gen
 
 ### Changes compared to the W3C specifications
 
-There are changes on how `Sensor` objects are obtained. In this API `Sensor objects are not constructed, but exposed via the [`Board`](../board/README.md) object. Also, this API lists all sensors of a given type, not only the default one. Also, this API adds two more properties to the `Sensor` object, for exposing a sensor name, and the name of the hardware controller. In rest, the sensor interfaces are the same.
+This API supports listing all sensors of a given type. Sensors can be constructed using additional optional properties: sensor name, the name of the hardware controller, the board object, and list of pin names used on the board. In rest, the sensor interfaces are the same. When board is not specified to a constructor, it takes the default board selected by the underlying platform.
 
-## Web IDL for Sensor APIs
+On boards where hot-plug sensors are supported, events are emitted when sensors are added, and removed, respectively.
+
+### Example
+
+```javascript
+var iot = require("iot-sensors");
+
+var temperature = iot.sensors("Temperature")[0];
+
+// if no temperature sensors already listed, try adding it
+if (!temperature) try {
+  temperature = new TemperatureSensor({
+      name: "livingRoomTemperature1",
+      controller: "BME280",
+      pins: ["i2c0"]  // connected to I2C bus 0
+      // board is default
+  });
+} catch(err) {
+  console.log("Error adding temperature sensor: " + err.message);
+}
+
+console.log("Living room temperature [C]: " + temperature.celsius);
+
+```
+
+### Web IDL for Sensor APIs
 ```javascript
 // Provided by 'require()'.
 interface Sensors {
     // Enumerate all sensors or a given type of sensors connected to the board.
     // If a type was provided, the first in the list is the default sensor of that type.
     sequence<Sensor> sensors(optional SensorType sensorType);
+
     attribute EventHandler<Sensor> onsensorfound;
     attribute EventHandler<Sensor> onsensorlost;
 };
@@ -35,20 +61,87 @@ partial interface Sensor {
     // Additional properties to W3C Generic Sensor.
     readonly attribute String name;  // e.g. "bedroomLightSensor1"
     readonly attribute String controller;  // e.g. "ISL29035", or "Grove" etc.
+    readonly attribute Board board;
+    readonly attribute sequence<String> pins;  // list of connected pin names
 };
 
-// Using the 'instanceof' type names for the W3C sensor types.
 enum SensorType {
-    "AmbientLightSensor",
     "Accelerometer",
-    "GeolocationSensor",
+    "Geolocation",
     "Gyroscope",
+    "Lightmeter",
     "Magnetometer",
-    "ProximitySensor"
+    "Proximity",
+    "Temperature"
+};
+
+partial dictionary SensorOptions {
+    String name;
+    String controller;
+    Board board;
+    sequence<String> pins;
 };
 ```
 
-The Web IDL of [Generic Sensor](https://w3c.github.io/sensors/#the-sensor-interface) is the following:
+Various sensors may add properties to [`Sensor`](#sensor), or to its `reading` property of type `SensorReading`.
+
+###  The data model for `Lightmeter`
+The `reading` property of the [`Lightmeter`](https://w3c.github.io/ambient-light/#ambient-light-sensor-interface) sensor object is a dictionary that contains a new property named `illuminance` that is a floating point number and represents the current light level (illuminance) measured in lux.
+
+### The data model for `ProximitySensor`
+The `reading` property of the [`ProximitySensor`](https://w3c.github.io/proximity/#proximity-sensor-interface) object is a dictionary that contains the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| distance   | double | no       | undefined     | distance to object in cm |
+| max        | double | no       | undefined     | sensing range in cm      |
+| near       | boolean | no      | undefined     | if object in proximity   |
+
+### The data model for `Accelerometer`
+The `reading` property of the sensor object [`Accelerometer`](https://w3c.github.io/accelerometer/#accelerometer-sensor-interface) object is a dictionary that contains the following properties:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| accelerationX | double | no    | undefined  | acceleration along the X axis |
+| accelerationY | double | no    | undefined  | acceleration along the Y axis |
+| accelerationZ | double | no    | undefined  | acceleration along the Z axis |
+
+The sensor contains one more additional property named `includesGravity` of type `boolean`. If it is `false`, then the `reading` property stores linear acceleration values (that don't take into account gravity).
+
+### The data model for `Gyroscope`
+The `reading` property of the [`Gyroscope`](https://w3c.github.io/gyroscope/#gyroscope-sensor-interface) sensor object is a dictionary that contains the following properties that represent the current angular velocity around the X, Y or Z axis, expressed in radians per second:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| rotationRateX | double | no    | 0  | angular velocity along the X axis |
+| rotationRateY | double | no    | 0  | angular velocity along the Y axis |
+| rotationRateZ | double | no    | 0  | angular velocity along the Z axis |
+
+### The data model for `Magnetometer`
+The `reading` property of the [`Magnetometer`](https://w3c.github.io/magnetometer/#magnetometer-interface) sensor object is a dictionary that contains the following properties that represent the geomagnetic field force around the X, Y or Z axis, expressed in microTesla units:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| magneticFieldX | double | no    | 0  | geomagnetic field along the X axis |
+| magneticFieldY | double | no    | 0  | geomagnetic field along the Y axis |
+| magneticFieldZ | double | no    | 0  | geomagnetic field along the Z axis |
+
+
+### The data model for geolocation
+Work in progress.
+
+### The data model for `TemperatureSensor`
+The `reading` property of the `TemperatureSensor` object is a dictionary that contains the following properties that represent the temperature given in Celsius, Kelvin, and Fahrenheit:
+
+| Property   | Type   | Optional | Default value | Represents |
+| ---        | ---    | ---      | ---           | ---        |
+| celsius    | double | no    | 0  | temperature in Celsius |
+| fahrenheit | double | no    | 0  | temperature in Fahrenheit |
+| kelvin     | double | no    | 0  | temperature in Kelvin |
+
+
+## The Web IDL of [W3C Generic Sensor](https://w3c.github.io/sensors/#the-sensor-interface)
+
 <a name="sensor">
 ```javascript
 interface Sensor : EventTarget {
@@ -86,49 +179,3 @@ dictionary SensorReadingEventInit : EventInit {
 };
 
 ```
-Various sensors may add properties to [`Sensor`](#sensor), or to its `reading` property of type `SensorReading`.
-
-###  The data model for lightmeter
-The `reading` property of the sensor is a dictionary that contains a new property named `illuminance` that is a floating point number and represents the current light level (illuminance) measured in lux.
-
-### The data model for proximity sensor
-The `reading` property of the sensor is a dictionary that contains the following properties:
-
-| Property   | Type   | Optional | Default value | Represents |
-| ---        | ---    | ---      | ---           | ---        |
-| distance   | double | no       | undefined     | distance to object in cm |
-| max        | double | no       | undefined     | sensing range in cm      |
-| near       | boolean | no      | undefined     | if object in proximity   |
-
-### The data model for accelerometer
-The `reading` property of the sensor is a dictionary that contains the following properties:
-
-| Property   | Type   | Optional | Default value | Represents |
-| ---        | ---    | ---      | ---           | ---        |
-| accelerationX | double | no    | undefined  | acceleration along the X axis |
-| accelerationY | double | no    | undefined  | acceleration along the Y axis |
-| accelerationZ | double | no    | undefined  | acceleration along the Z axis |
-
-The sensor contains one more additional property named `includesGravity` of type `boolean`. If it is `false`, then the `reading` property stores linear acceleration values (that don't take into account gravity).
-
-### The data model for gyroscope
-The `reading` property of the sensor is a dictionary that contains the following properties that represent the current angular velocity around the X, Y or Z axis, expressed in radians per second:
-
-| Property   | Type   | Optional | Default value | Represents |
-| ---        | ---    | ---      | ---           | ---        |
-| rotationRateX | double | no    | 0  | angular velocity along the X axis |
-| rotationRateY | double | no    | 0  | angular velocity along the Y axis |
-| rotationRateZ | double | no    | 0  | angular velocity along the Z axis |
-
-### The data model for magnetometer
-The `reading` property of the sensor is a dictionary that contains the following properties that represent the geomagnetic field force around the X, Y or Z axis, expressed in microTesla units:
-
-| Property   | Type   | Optional | Default value | Represents |
-| ---        | ---    | ---      | ---           | ---        |
-| magneticFieldX | double | no    | 0  | geomagnetic field along the X axis |
-| magneticFieldY | double | no    | 0  | geomagnetic field along the Y axis |
-| magneticFieldZ | double | no    | 0  | geomagnetic field along the Z axis |
-
-
-### The data model for geolocation
-Work in progress.


### PR DESCRIPTION
Add Bluetooth Smart API
OCF: add support for resource translation.
Change OCF request response: use a respond() and error() method on the request object, like with the Bluetooth Smart API.
Add tables of content. Editorial changes. Fix permission steps.
