### PR TITLE
Generate a JSON format file for the test results

### DIFF
--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 var success = "\x1b[42;30m✓\x1b[0m",
-	failure = "\x1b[41;30m✗\x1b[0m";
-
+	failure = "\x1b[41;30m✗\x1b[0m",
+	results = require( "./getresult" );
+    
 // Right-align runtime in a field that's 10 columns wide
 function formatRuntime( runtime ) {
 	var index,
@@ -48,6 +49,8 @@ module.exports = {
 	log: function( status ) {
 
 		// Parameters: status: { module, result(t/f), message, actual, expected, testId, runtime }
+
+		results.getTestResult( status, success, failure );
 
 		console.log(
 			( status.result ? success : failure ) +

--- a/lib/getresult.js
+++ b/lib/getresult.js
@@ -1,0 +1,39 @@
+var fs = require( "fs" );
+
+var jsonFilename = require( "path" ).resolve( __dirname, "results.json" );
+
+var date = new Date(),
+	data = "",
+	caseList = [],
+	setList = [],
+	allList = [],
+	test = {},
+	testInfo = {};
+
+exports.getTestResult = function( status, success, failure ) {
+
+if ( status.result ) {
+	success = "PASS";
+} else if ( !status.result ) {
+	failure = "FAIL";
+}
+
+testInfo = {
+	"message": ( status.runtime + ": " + status.message ),
+	"result": ( status.result ? success : failure ),
+	"runtime": ( date.toLocaleTimeString() )
+};
+
+if ( setList.indexOf( status.name ) > -1 && ( "results" in test ) ) {
+	test.results.push( testInfo );
+	caseList.push( test );
+} else {
+	setList.push( status.name );
+	test = { "test": status.name, "results": [ testInfo ] };
+	caseList.push( test );
+	allList.push( test );
+}
+
+data = JSON.stringify( { "output": allList }, null, 4 );
+fs.writeFileSync( jsonFilename, data );
+};


### PR DESCRIPTION
- Generate a JSON format file to hold the detailed test results for failure analysis.
- Keep the JSON format the same as [iotivity-node](https://github.com/otcshare/iotivity-node) for QA statistics.
